### PR TITLE
Added validation For empty objects on images.blade.php

### DIFF
--- a/resources/views/default/form/element/images.blade.php
+++ b/resources/views/default/form/element/images.blade.php
@@ -14,7 +14,7 @@
 		<div>
 			<div class="btn btn-primary imageBrowse"><i class="fa fa-upload"></i> {{ trans('sleeping_owl::lang.image.browseMultiple') }}</div>
 		</div>
-		<input name="{{ $name }}" class="imageValue" type="hidden" value="{{ implode(',', $value) }}">
+		<input name="{{ $name }}" class="imageValue" type="hidden" value="{{ !empty($value) && sizeof($value) != 0 ? implode(',', $value) : "" }}">
 		<div class="errors">
 			@include(AdminTemplate::getViewPath('form.element.errors'))
 		</div>


### PR DESCRIPTION
Added a quick validation for empty objects on images.blade.php when using the form element images. In the old way if the object returned [] i've get errors saying that implode cant do nothing and form dont show.