### PR TITLE
Возможность добавлять Select/MultiSelect с опциями без Relation.

### DIFF
--- a/src/Display/Column/Email.php
+++ b/src/Display/Column/Email.php
@@ -6,7 +6,7 @@ class Email extends NamedColumn
 {
     /**
      * Email constructor.
-     * 
+     *
      * @param null|string $name
      * @param null|string $label
      */

--- a/src/Display/Column/NamedColumn.php
+++ b/src/Display/Column/NamedColumn.php
@@ -80,7 +80,7 @@ abstract class NamedColumn extends TableColumn implements NamedColumnInterface
 
         if ($instance instanceof Collection) {
             $instance = $instance->pluck($part);
-        } else if (! is_null($instance)) {
+        } elseif (! is_null($instance)) {
             $instance = $instance->getAttribute($part);
         }
 

--- a/src/Display/Column/RelatedLink.php
+++ b/src/Display/Column/RelatedLink.php
@@ -17,7 +17,6 @@ class RelatedLink extends Link
     protected $originalName;
 
     /**
-     *
      * @param null|string $name
      * @param null|string $label
      * @param Model|null  $model

--- a/src/Display/Column/Url.php
+++ b/src/Display/Column/Url.php
@@ -13,7 +13,7 @@ class Url extends NamedColumn
     public function __construct($name, $label = null)
     {
         parent::__construct($name, $label);
-        
+
         $this->setHtmlAttribute('class', 'row-url');
     }
 

--- a/src/Form/Element/MultiSelect.php
+++ b/src/Form/Element/MultiSelect.php
@@ -44,7 +44,7 @@ class MultiSelect extends Select
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isTaggable()
     {
@@ -62,7 +62,7 @@ class MultiSelect extends Select
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isDeleteRelatedItem()
     {
@@ -124,10 +124,9 @@ class MultiSelect extends Select
         $relation = $this->getModel()->{$attribute}();
 
         if ($relation instanceof \Illuminate\Database\Eloquent\Relations\BelongsToMany) {
-
             foreach ($values as $i => $value) {
                 if (! array_key_exists($value, $this->getOptions()) and $this->isTaggable()) {
-                    $model = clone($this->getModelForOptions());
+                    $model = clone $this->getModelForOptions();
                     $model->{$this->getDisplay()} = $value;
                     $model->save();
 
@@ -136,8 +135,7 @@ class MultiSelect extends Select
             }
 
             $relation->sync($values);
-        } else if ($relation instanceof \Illuminate\Database\Eloquent\Relations\HasMany) {
-
+        } elseif ($relation instanceof \Illuminate\Database\Eloquent\Relations\HasMany) {
             foreach ($relation->get() as $item) {
                 if (! in_array($item->getKey(), $values)) {
                     if ($this->isDeleteRelatedItem()) {
@@ -151,7 +149,7 @@ class MultiSelect extends Select
 
             foreach ($values as $i => $value) {
                 /** @var Model $model */
-                $model = clone($this->getModelForOptions());
+                $model = clone $this->getModelForOptions();
                 $item = $model->find($value);
 
                 if (is_null($item)) {

--- a/src/Form/Element/Select.php
+++ b/src/Form/Element/Select.php
@@ -155,9 +155,9 @@ class Select extends NamedFormElement
      * @param bool $state
      * @return $this
      */
-    public function setEmptyRelation(bool $state)
+    public function onlyEmptyRelation()
     {
-        $this->isEmptyRelation = $state;
+        $this->isEmptyRelation = true;
 
         return $this;
     }
@@ -234,7 +234,7 @@ class Select extends NamedFormElement
             $options->where($this->getModel()->getForeignKey(), 0);
         }
 
-        $options = $options->get()->lists($this->getDisplay(), $key);
+        $options = $options->get()->pluck($this->getDisplay(), $key);
 
         if ($options instanceof Collection) {
             $options = $options->all();

--- a/src/Form/Element/Select.php
+++ b/src/Form/Element/Select.php
@@ -34,6 +34,11 @@ class Select extends NamedFormElement
     protected $sortable = true;
 
     /**
+     * @var bool
+     */
+    protected $isEmptyRelation = false;
+
+    /**
      * @param string      $path
      * @param string|null $label
      * @param array|Model       $options
@@ -147,6 +152,25 @@ class Select extends NamedFormElement
     }
 
     /**
+     * @param bool $state
+     * @return $this
+     */
+    public function setEmptyRelation(bool $state)
+    {
+        $this->isEmptyRelation = $state;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmptyRelation()
+    {
+        return $this->isEmptyRelation;
+    }
+
+    /**
      * @param bool $sortable
      *
      * @return $this
@@ -195,12 +219,21 @@ class Select extends NamedFormElement
         ];
     }
 
+    /**
+     * @var $repository RepositoryInterface
+     */
     protected function loadOptions()
     {
         $repository = app(RepositoryInterface::class, [$this->getModelForOptions()]);
 
         $key = $repository->getModel()->getKeyName();
-        $options = $repository->getQuery()->get()->lists($this->getDisplay(), $key);
+
+        $options = $repository->getQuery();
+
+        if($this->isEmptyRelation())
+            $options->where($this->getModel()->getForeignKey(), 0);
+
+        $options = $options->get()->lists($this->getDisplay(), $key);
 
         if ($options instanceof Collection) {
             $options = $options->all();

--- a/src/Form/Element/Select.php
+++ b/src/Form/Element/Select.php
@@ -49,7 +49,7 @@ class Select extends NamedFormElement
 
         if (is_array($options)) {
             $this->setOptions($options);
-        } else if ($options instanceof Model) {
+        } elseif ($options instanceof Model) {
             $this->setModelForOptions($options);
         }
     }
@@ -215,12 +215,12 @@ class Select extends NamedFormElement
         return parent::toArray() + [
             'options'  => $this->getOptions(),
             'nullable' => $this->isNullable(),
-            'attributes' => $attributes
+            'attributes' => $attributes,
         ];
     }
 
     /**
-     * @var $repository RepositoryInterface
+     * @var RepositoryInterface
      */
     protected function loadOptions()
     {
@@ -230,8 +230,9 @@ class Select extends NamedFormElement
 
         $options = $repository->getQuery();
 
-        if($this->isEmptyRelation())
+        if ($this->isEmptyRelation()) {
             $options->where($this->getModel()->getForeignKey(), 0);
+        }
 
         $options = $options->get()->lists($this->getDisplay(), $key);
 

--- a/src/Traits/SqlQueryOperators.php
+++ b/src/Traits/SqlQueryOperators.php
@@ -7,7 +7,6 @@ use SleepingOwl\Admin\Exceptions\FilterOperatorException;
 
 trait SqlQueryOperators
 {
-
     /**
      * @var string
      */


### PR DESCRIPTION
Может понадобиться при реализации админпанелеей к закрытым клубам - в которых членство выдается один раз.

пример:
```php
AdminFormElement::multiselect('users', 'Пользователи')
                ->setModelForOptions(new User())
                ->setEmptyRelation(true)
                ->setDisplay('full_name')
```
![uaazb90](https://cloud.githubusercontent.com/assets/737550/14406674/38a429de-feb7-11e5-94a7-bcc7100e4318.png)
```php
AdminFormElement::multiselect('users', 'Пользователи')
                ->setModelForOptions(new User())
                ->setEmptyRelation(false)
                ->setDisplay('full_name')
```
![gp0kscp](https://cloud.githubusercontent.com/assets/737550/14406680/79092588-feb7-11e5-947f-e25cc680c3b2.png)

По умолчанию: **false**

