### PR TITLE
Require files bugfix

### DIFF
--- a/src/Providers/AdminServiceProvider.php
+++ b/src/Providers/AdminServiceProvider.php
@@ -114,7 +114,7 @@ class AdminServiceProvider extends ServiceProvider
             });
 
         foreach ($files as $file) {
-            require $file;
+            require_once $file;
         }
     }
 
@@ -127,7 +127,7 @@ class AdminServiceProvider extends ServiceProvider
     {
         if (file_exists($file = $this->getBootstrapPath('routes.php'))) {
             $this->registerRoutes(function () use ($file) {
-                require $file;
+                require_once $file;
             });
         }
     }
@@ -168,7 +168,7 @@ class AdminServiceProvider extends ServiceProvider
             }
 
             if (file_exists($routesFile = __DIR__.'/../Http/routes.php')) {
-                require $routesFile;
+                require_once $routesFile;
             }
         });
     }


### PR DESCRIPTION
When extending any of your Display/Column or Form/Element classes inside a folder that is being autoloaded, your code tried to require them again, causing a "Cannot redeclare class" error. This should fix the issue.

If you don't understand what I'm saying, checkout my "lurk" project ("admin-sample" branch). Under "app/Admin/Addons/Display/Column/Hash.php" you can find my custom Display/Column class.
(PS: I also adapted some of your english on my project. Feel free to copy it.)
