### PR TITLE
Added support for fetch specific columns from database and make dynamic option display text from Form\Element\Select using Model for options. Solve #121.

### DIFF
--- a/src/Form/Element/Select.php
+++ b/src/Form/Element/Select.php
@@ -237,7 +237,7 @@ class Select extends NamedFormElement
         }
 
         $this->fetchColumns = $columns;
-        
+
         return $this;
     }
 

--- a/src/Form/Element/Select.php
+++ b/src/Form/Element/Select.php
@@ -230,7 +230,8 @@ class Select extends NamedFormElement
      * @param string|array $columns
      * @return $this
      */
-    public function setFetchColumns($columns) {
+    public function setFetchColumns($columns)
+    {
         if (! is_array($columns)) {
             $columns = func_get_args();
         }
@@ -240,11 +241,12 @@ class Select extends NamedFormElement
     }
 
     /**
-     * Get the fetch columns
+     * Get the fetch columns.
      *
      * @return array
      */
-    public function getFetchColumns() {
+    public function getFetchColumns()
+    {
         return $this->fetchColumns;
     }
 
@@ -334,7 +336,7 @@ class Select extends NamedFormElement
             $options->where($this->getForeignKey(), 0)->orWhereNull($this->getForeignKey());
         }
 
-        if (!is_null($this->fetchColumns)) {
+        if (! is_null($this->fetchColumns)) {
             $columns = array_merge([$key], $this->fetchColumns);
             $options->select($columns);
         }
@@ -352,19 +354,17 @@ class Select extends NamedFormElement
 
             // iterate for all options and redefine it as
             // list of KEY and TEXT pair
-            $options = array_map(function($opt) use ($key, $makeDisplay) {
+            $options = array_map(function ($opt) use ($key, $makeDisplay) {
                 // get the KEY and make the display text
                 return [data_get($opt, $key), $makeDisplay($opt)];
             }, $options);
 
             // take options as array with KEY => VALUE pair
             $options = Arr::pluck($options, 1, 0);
-        }
-        elseif ($options instanceof Collection) {
+        } elseif ($options instanceof Collection) {
             // take options as array with KEY => VALUE pair
             $options = Arr::pluck($options->all(), $this->getDisplay(), $key);
-        }
-        else {
+        } else {
             // take options as array with KEY => VALUE pair
             $options = Arr::pluck($options, $this->getDisplay(), $key);
         }

--- a/src/Form/Element/Select.php
+++ b/src/Form/Element/Select.php
@@ -2,6 +2,7 @@
 
 namespace SleepingOwl\Admin\Form\Element;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use SleepingOwl\Admin\Contracts\RepositoryInterface;
@@ -48,6 +49,11 @@ class Select extends NamedFormElement
      * @var string|null
      */
     protected $foreignKey = null;
+
+    /**
+     * @var array
+     */
+    protected $fetchColumns = [];
 
     /**
      * @param string      $path
@@ -210,6 +216,39 @@ class Select extends NamedFormElement
     }
 
     /**
+     * Set Only fetch columns.
+     *
+     * If use {@link Select#setModelForOptions($model)}, on fetch
+     * data from the $model table, only specified columns has be
+     * feched.
+     *
+     * Examples: <code>setFetchColumns('title')</code> or
+     * <code>setFetchColumns(['title'])</code> or
+     * <code>setFetchColumns('title', 'position')</code> or
+     * <code>setFetchColumns(['title', 'position'])</code>.
+     *
+     * @param string|array $columns
+     * @return $this
+     */
+    public function setFetchColumns($columns) {
+        if (! is_array($columns)) {
+            $columns = func_get_args();
+        }
+
+        $this->fetchColumns = $columns;
+        return $this;
+    }
+
+    /**
+     * Get the fetch columns
+     *
+     * @return array
+     */
+    public function getFetchColumns() {
+        return $this->fetchColumns;
+    }
+
+    /**
      * @param array $keys
      *
      * @return $this
@@ -295,10 +334,39 @@ class Select extends NamedFormElement
             $options->where($this->getForeignKey(), 0)->orWhereNull($this->getForeignKey());
         }
 
-        $options = $options->get()->pluck($this->getDisplay(), $key);
+        if (!is_null($this->fetchColumns)) {
+            $columns = array_merge([$key], $this->fetchColumns);
+            $options->select($columns);
+        }
 
-        if ($options instanceof Collection) {
-            $options = $options->all();
+        $options = $options->get();
+
+        if (is_callable($this->getDisplay())) {
+            // make dynamic display text
+            if ($options instanceof Collection) {
+                $options = $options->all();
+            }
+
+            // the maker
+            $makeDisplay = $this->getDisplay();
+
+            // iterate for all options and redefine it as
+            // list of KEY and TEXT pair
+            $options = array_map(function($opt) use ($key, $makeDisplay) {
+                // get the KEY and make the display text
+                return [data_get($opt, $key), $makeDisplay($opt)];
+            }, $options);
+
+            // take options as array with KEY => VALUE pair
+            $options = Arr::pluck($options, 1, 0);
+        }
+        elseif ($options instanceof Collection) {
+            // take options as array with KEY => VALUE pair
+            $options = Arr::pluck($options->all(), $this->getDisplay(), $key);
+        }
+        else {
+            // take options as array with KEY => VALUE pair
+            $options = Arr::pluck($options, $this->getDisplay(), $key);
         }
 
         $this->setOptions($options);

--- a/src/Form/Element/Select.php
+++ b/src/Form/Element/Select.php
@@ -237,6 +237,7 @@ class Select extends NamedFormElement
         }
 
         $this->fetchColumns = $columns;
+        
         return $this;
     }
 


### PR DESCRIPTION
Added support for fetch specific columns from database and make dynamic option display text from Form\Element\Select using Model for options. Solve #121.

Use dynamic option display text:

```php
AdminFormElement::select('mymodel_id', 'Mymodel')
    ->setModelForOptions(\App\Mymodel::class)
    ->setDisplay(function($option) {
        return "#{$option->id}: {$option->title}";
    })
```

Use fetch specific columns for options:

```php
AdminFormElement::select('mymodel_id', 'Mymodel')
    ->setModelForOptions(\App\Mymodel::class)
    ->setFetchColumns('created_at')
    // Only PK and 'created_at' fields is available
    ->setDisplay('created_at');

// or

AdminFormElement::select('mymodel_id', 'Mymodel')
    ->setModelForOptions(\App\Mymodel::class)
    ->setFetchColumns('title', 'created_at')
    ->setDisplay(function($opt) {
        // Only PK, 'title' and 'created_at' fields is available
        return "{$opt->title} created at {$opt->created_at}";
    });

```