### PR TITLE
Fix empty button dropdown

### DIFF
--- a/resources/views/default/form/buttons.blade.php
+++ b/resources/views/default/form/buttons.blade.php
@@ -11,26 +11,28 @@
                 class="btn btn-primary btn-flat">
             <i class="fa fa-check"></i> {{ $saveButtonText }}
         </button>
-        <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <i class="fa fa-caret-down"></i>
-        </button>
-        <div class="dropdown-menu btn-actions">
-            <div class="btn-group-vertical">
-                @if($showSaveAndCloseButton)
-                    <button type="submit" name="next_action" value="save_and_close" class="btn btn-success btn-block btn-flat">
-                        <i class="fa fa-check"></i>
-                        {{ $saveAndCloseButtonText }}
-                    </button>
-                @endif
-                @if($showSaveAndCreateButton)
-                    <div role="separator" class="divider"></div>
-                    <button type="submit" name="next_action" value="save_and_create" class="btn btn-info btn-block btn-flat">
-                        <i class="fa fa-check"></i>
-                        {{ $saveAndCreateButtonText }}
-                    </button>
-                @endif
+        @if($showSaveAndCloseButton or $showSaveAndCreateButton)
+            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <i class="fa fa-caret-down"></i>
+            </button>
+            <div class="dropdown-menu btn-actions">
+                <div class="btn-group-vertical">
+                    @if($showSaveAndCloseButton)
+                        <button type="submit" name="next_action" value="save_and_close" class="btn btn-success btn-block btn-flat">
+                            <i class="fa fa-check"></i>
+                            {{ $saveAndCloseButtonText }}
+                        </button>
+                    @endif
+                    @if($showSaveAndCreateButton)
+                        <div role="separator" class="divider"></div>
+                        <button type="submit" name="next_action" value="save_and_create" class="btn btn-info btn-block btn-flat">
+                            <i class="fa fa-check"></i>
+                            {{ $saveAndCreateButtonText }}
+                        </button>
+                    @endif
+                </div>
             </div>
-        </div>
+        @endif
     </div>
 
     <a href="{{ $backUrl }}" class="btn btn-link">


### PR DESCRIPTION
Little fix empty dropdown menu if you use `$form->getButtons()->hideSaveAndCloseButton()->hideSaveAndCreateButton();` 
![image](https://cloud.githubusercontent.com/assets/11852682/15422842/236e1dc2-1e83-11e6-919a-36841ab6fd3f.png) 

P.S. Только кнопка сохранения нужна для страниц настроек, например. Да и в любом случае, если не так, то как-нибудь лучше это исправить, чтобы не заменять вручную всю вьюшку на свою при необходимости.
