### PR TITLE
Fixed bug where pagination was enabled by default without a default for pageName.

### DIFF
--- a/src/Display/DisplayTable.php
+++ b/src/Display/DisplayTable.php
@@ -40,7 +40,7 @@ class DisplayTable extends Display
     /**
      * @var string
      */
-    protected $pageName;
+    protected $pageName = 'name';
 
     /**
      * @var Collection


### PR DESCRIPTION
DisplayTable had pagination enabled by default, but the value for pageName was not set. This would cause a case where the url would be something like /admin/records?=2. I set pageName to default to 'page' in order to avoid this bug.