### PR TITLE
DatatablesAsync: Строка поиска может быть пустой

### DIFF
--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -208,7 +208,7 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
     protected function applySearch(Builder $query)
     {
         $search = Request::input('search.value');
-        if (is_null($search)) {
+        if (empty($search)) {
             return;
         }
 


### PR DESCRIPTION
Если в таблице есть поля типа `SleepingOwl\Admin\Display\Column\Text`, то даже при пустом введенном поле поиска, для них будет строиться поисковый запрос вида `where ("text_field_1" like '%%' or "text_field_2" like '%%')`.

Возможно так же стоит добавить поиск по полям типа `Link`, `RelatedLink`, `Email` и `Lists`, так как они в принципе тоже являются текстовыми.