### PR TITLE
move applyOrders in front of modifyQuery

### DIFF
--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -139,6 +139,7 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
             $filteredCount = $query->distinct()->count($this->getDistinct());
         }
 
+        $this->applyOrders($query);
         $this->modifyQuery($query);
         $this->applySearch($query);
         $this->applyColumnSearch($query);
@@ -147,7 +148,6 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
             $filteredCount = $query->count();
         }
 
-        $this->applyOrders($query);
         $this->applyOffset($query);
         $collection = $query->get();
 


### PR DESCRIPTION
modifyQuery apply pre-defined order for query, but applyOrders accepts
user defined order, user defined order must come first to take effect.