### PR TITLE
Use alias insteadof model name as page id in case id is absent

### DIFF
--- a/src/Navigation/Page.php
+++ b/src/Navigation/Page.php
@@ -57,8 +57,8 @@ class Page extends \KodiComponents\Navigation\Page
      */
     public function getId()
     {
-        if (is_null($this->id) and $this->hasModel()) {
-            return $this->model;
+        if (is_null($this->id)) {
+            return $this->getModelConfiguration()->getAlias();
         }
 
         return parent::getId();


### PR DESCRIPTION
Previous id detection didn't allow to use one model on several section pages.