### PR TITLE
fix problem with custom validation messages

### DIFF
--- a/resources/views/default/form/element/errors.blade.php
+++ b/resources/views/default/form/element/errors.blade.php
@@ -1,3 +1,3 @@
 @foreach ($errors->get($path) as $error)
-	<p class="help-block">{{ $error }}</p>
+	<p class="help-block">{!! $error !!}</p>
 @endforeach

--- a/src/Traits/FormElements.php
+++ b/src/Traits/FormElements.php
@@ -171,7 +171,7 @@ trait FormElements
     {
         $this->getElements()->each(function ($element) use (&$messages) {
             $element = $this->getElementContainer($element);
-            if ($element instanceof NamedFormElement) {
+            if ($element instanceof FormElementInterface) {
                 $messages += $element->getValidationMessages();
             }
         });


### PR DESCRIPTION
Providing custom validation messages via required(), addValidationRule() didn't work.
It caused by mismatching class types when trying to retrieve messages.

Also, I had changed blade template to be able to output messages with markup, sometimes you need to make some parts of text bolder or italic.