### PR TITLE
make custom column orderable

### DIFF
--- a/src/Display/Column/Custom.php
+++ b/src/Display/Column/Custom.php
@@ -20,6 +20,12 @@ class Custom extends TableColumn
     protected $view = 'column.custom';
 
     /**
+     * A field that can be ordered
+     * @var string
+     */
+    protected $orderField;
+
+    /**
      * Custom constructor.
      *
      * @param null|string $label
@@ -51,6 +57,26 @@ class Custom extends TableColumn
         $this->callback = $callback;
 
         return $this;
+    }
+
+    /**
+     * @param string $field
+     *
+     * @return $this
+     */
+    public function setOrderField($field)
+    {
+        $this->orderField = $field;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrderField()
+    {
+        return $this->orderField;
     }
 
     /**

--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -11,6 +11,7 @@ use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 use SleepingOwl\Admin\Display\Column\Email;
 use SleepingOwl\Admin\Display\Column\Link;
 use SleepingOwl\Admin\Display\Column\Text;
+use SleepingOwl\Admin\Display\Column\Custom;
 use SleepingOwl\Admin\Display\Column\NamedColumn;
 use SleepingOwl\Admin\Contracts\WithRoutesInterface;
 
@@ -209,6 +210,9 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
 
             if ($column instanceof NamedColumn && $column->isOrderable()) {
                 $name = $column->getName();
+                $query->orderBy($name, $orderDirection);
+            } elseif ($column instanceof Custom && $column->getOrderField()) {
+                $name = $column->getOrderField();
                 $query->orderBy($name, $orderDirection);
             }
         }


### PR DESCRIPTION
In the old datatables model only named columns can be ordered, but some custom columns can also be ordered, I think it's a very useful feature.

e.g. a column name is `author_id`, use 
```php
AdminColumn::custom()->setLabel('author')->setCallback(function ($model) {
                return $model->author->name;
            })->setOrderField('author_id'),
```

then when we can toggle order for the author column order by author_id