### PR TITLE
fix AdminColumnEditable ajax url error

### DIFF
--- a/resources/views/default/column/editable/checkbox.blade.php
+++ b/resources/views/default/column/editable/checkbox.blade.php
@@ -3,7 +3,7 @@
        class="inline-editable"
        data-name="{{ $name }}"
        data-value="{{ $value }}"
-       data-url="{{ request()->url() }}"
+       data-url="{{ strstr(request()->url(), 'async', true) }}"
        data-type="checklist"
        data-pk="{{ $id }}"
        data-source="{ 1 : '{{ $checkedLabel }}' }"


### PR DESCRIPTION
In `datatablesAsync`, if we use `AdminColumnEditable::checkbox` the returned item will have a `data-url` attribute suffixed with `async`,  this URL is not able to post an update request.

also to use `AdminColumnEditable::checkbox` in `datatablesAsync`, we will have to bind a datatable event, in my case I use:
```javascript
$(document).ready(function () {
    $('.datatables').on('draw.dt', function() {
        $(".inline-editable").editable();
    });
});
```