### PR TITLE
Fix for order by first column

### DIFF
--- a/src/Display/DisplayTable.php
+++ b/src/Display/DisplayTable.php
@@ -239,7 +239,7 @@ class DisplayTable extends Display
             $columnIndex = array_get($order, 'column');
             $direction = array_get($order, 'dir', 'asc');
 
-            if (! $columnIndex) {
+            if (! $columnIndex && $columnIndex !== '0') {
                 continue;
             }
 


### PR DESCRIPTION
First column has index '0', that was reason for not sortable by first column.