### PR TITLE
Add custom methods for hide buttons in control column

### DIFF
--- a/src/Display/Column/Control.php
+++ b/src/Display/Column/Control.php
@@ -125,7 +125,7 @@ class Control extends TableColumn
      * @param $editable
      * @return $this
      */
-    protected function setEditable($editable)
+    public function setEditable($editable)
     {
         $this->editable = (bool) $editable;
 

--- a/src/Display/Column/Control.php
+++ b/src/Display/Column/Control.php
@@ -122,7 +122,7 @@ class Control extends TableColumn
     }
 
     /**
-     * @param $editable
+     * @param bool $editable
      * @return $this
      */
     public function setEditable($editable)
@@ -133,7 +133,7 @@ class Control extends TableColumn
     }
 
     /**
-     * @param $deletable
+     * @param bool $deletable
      * @return $this
      */
     public function setDeletable($deletable)
@@ -144,7 +144,7 @@ class Control extends TableColumn
     }
 
     /**
-     * @param $destroyable
+     * @param bool $destroyable
      * @return $this
      */
     public function setDestroyable($destroyable)
@@ -155,7 +155,7 @@ class Control extends TableColumn
     }
 
     /**
-     * @param $restorable
+     * @param bool $restorable
      * @return $this
      */
     public function setRestorable($restorable)

--- a/src/Display/Column/Control.php
+++ b/src/Display/Column/Control.php
@@ -27,6 +27,26 @@ class Control extends TableColumn
     protected $buttons;
 
     /**
+     * @var bool
+     */
+    protected $editable = true;
+
+    /**
+     * @var bool
+     */
+    protected $deletable = true;
+
+    /**
+     * @var bool
+     */
+    protected $destroyable = true;
+
+    /**
+     * @var bool
+     */
+    protected $restorable = true;
+
+    /**
      * Control constructor.
      *
      * @param string|null $label
@@ -102,6 +122,50 @@ class Control extends TableColumn
     }
 
     /**
+     * @param $editable
+     * @return $this
+     */
+    protected function setEditable($editable)
+    {
+        $this->editable = (bool) $editable;
+
+        return $this;
+    }
+
+    /**
+     * @param $deletable
+     * @return $this
+     */
+    public function setDeletable($deletable)
+    {
+        $this->deletable = (bool) $deletable;
+
+        return $this;
+    }
+
+    /**
+     * @param $destroyable
+     * @return $this
+     */
+    public function setDestroyable($destroyable)
+    {
+        $this->destroyable = (bool) $destroyable;
+
+        return $this;
+    }
+
+    /**
+     * @param $restorable
+     * @return $this
+     */
+    public function setRestorable($restorable)
+    {
+        $this->restorable = (bool) $restorable;
+
+        return $this;
+    }
+
+    /**
      * Check if instance supports soft-deletes and trashed.
      *
      * @return bool
@@ -123,6 +187,8 @@ class Control extends TableColumn
     protected function isEditable()
     {
         return
+            $this->editable
+            &&
             ! $this->isTrashed()
             &&
             $this->getModelConfiguration()->isEditable(
@@ -138,6 +204,8 @@ class Control extends TableColumn
     protected function isDeletable()
     {
         return
+            $this->deletable
+            &&
             ! $this->isTrashed()
             &&
             $this->getModelConfiguration()->isDeletable(
@@ -153,6 +221,8 @@ class Control extends TableColumn
     protected function isDestroyable()
     {
         return
+            $this->destroyable
+            &&
             $this->isTrashed()
             &&
             $this->getModelConfiguration()->isDestroyable(
@@ -168,6 +238,8 @@ class Control extends TableColumn
     protected function isRestorable()
     {
         return
+            $this->restorable
+            &&
             $this->isTrashed()
             &&
             $this->getModelConfiguration()->isRestorable(


### PR DESCRIPTION
Иногда нужно скрыть кнопки в колонке управления. Например: не нужна кнопка удаления для отображения таблицы в качестве связанной сущности на странице редактирования другой сущности.

```
php
$display = \AdminDisplay::table();
...
$display->getColumns()->getControlColumn()->setDeletable(false);
```