### PR TITLE
Add Methods setRedirect, getRedirect

### DIFF
--- a/src/Model/SectionModelConfiguration.php
+++ b/src/Model/SectionModelConfiguration.php
@@ -10,6 +10,28 @@ use SleepingOwl\Admin\Contracts\Initializable;
 class SectionModelConfiguration extends ModelConfigurationManager
 {
     /**
+     * @var array
+     */
+    protected $redirect = ['edit' => 'edit', 'create' => 'edit'];
+
+    /**
+     * @param string $redirect
+     * @return void
+     */
+    public function setRedirect($redirect)
+    {
+        $this->redirect = $redirect;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRedirect()
+    {
+        return collect($this->redirect);
+    }
+
+    /**
      * @return bool
      */
     public function isCreatable()


### PR DESCRIPTION
fix error exception

`Class SleepingOwl\Admin\Model\SectionModelConfiguration contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (SleepingOwl\Admin\Contracts\ModelConfiguration  
  Interface::setRedirect, SleepingOwl\Admin\Contracts\ModelConfigurationInterface::getRedirect) `