### PR TITLE
Bigdata memory leak issue

### DIFF
--- a/src/Display/DisplayTable.php
+++ b/src/Display/DisplayTable.php
@@ -200,13 +200,16 @@ class DisplayTable extends Display
             return $this->collection;
         }
 
-        $query = $this->getRepository()->getQuery();
+        if ( ! ($this instanceof DisplayDatatablesAsync)) {
 
-        $this->modifyQuery($query);
+            $query = $this->getRepository()->getQuery();
 
-        return $this->collection = $this->usePagination()
-            ? $query->paginate($this->paginate, ['*'], $this->pageName)->appends(request()->except($this->pageName))
-            : $query->get();
+            $this->modifyQuery($query);
+
+            return $this->collection = $this->usePagination()
+                ? $query->paginate($this->paginate, ['*'], $this->pageName)->appends(request()->except($this->pageName))
+                : $query->get();
+         }
     }
 
     /**


### PR DESCRIPTION
Запустили на миллионных данных. Интерфейс асинхронных DataTables вызывает 1 запрос который запрашивает все данные с таблицы. Так как в этом месте у нас нет модификаций запроса. Ну и собственно cannot allocate memory

Если кто подскажет - буду рад)