### PR TITLE
PHP 7 оператор "..."

### DIFF
--- a/src/Model/ModelConfigurationManager.php
+++ b/src/Model/ModelConfigurationManager.php
@@ -513,7 +513,7 @@ abstract class ModelConfigurationManager implements ModelConfigurationInterface
      *
      * @return mixed
      */
-    public function fireEvent($event, $halt = true, Model $model = null, ...$payload)
+    public function fireEvent($event, $halt = true, Model $model = null, $payload = [])
     {
         if (! isset(self::$dispatcher)) {
             return true;


### PR DESCRIPTION
В PHP 7 ModelConfigurationManager выдаёт ошибку на 516 строке.
Почему бы не заменить  "...$payload" на "$payload = []"?
Раз уж мы принимаем его как необязательный параметр и как массив.