### PR TITLE
Фатальная ошибка при одновременно создании элемента и связанного элемента

### DIFF
--- a/src/Form/Element/MultiSelect.php
+++ b/src/Form/Element/MultiSelect.php
@@ -187,7 +187,7 @@ class MultiSelect extends Select
                 if ($this->isDeleteRelatedItem()) {
                     $item->delete();
                 } else {
-                    $item->{$relation->getPlainForeignKey()} = null;
+                    $item->{$relation->getForeignKeyName()} = null;
                     $item->save();
                 }
             }

--- a/src/Form/Element/MultiSelect.php
+++ b/src/Form/Element/MultiSelect.php
@@ -187,7 +187,7 @@ class MultiSelect extends Select
                 if ($this->isDeleteRelatedItem()) {
                     $item->delete();
                 } else {
-                    $item->{$relation->getForeignKeyName()} = null;
+                    $item->{$this->getForeignKeyNameFromRelation($relation)} = null;
                     $item->save();
                 }
             }

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -471,7 +471,7 @@ abstract class NamedFormElement extends FormElement
                         case HasOne::class:
                         case MorphOne::class:
                             $relatedModel = $relationObject->getRelated()->newInstance();
-                            $relatedModel->setAttribute($relationObject->getForeignKeyName(), $relationObject->getParentKey());
+                            $relatedModel->setAttribute($this->getForeignKeyNameFromRelation($relationObject), $relationObject->getParentKey());
                             $model->setRelation($relation, $relatedModel);
                             break;
                     }
@@ -490,6 +490,14 @@ abstract class NamedFormElement extends FormElement
         }
 
         return $model;
+    }
+
+    protected function getForeignKeyNameFromRelation($relation)
+    {
+        return method_exists($relation, 'getForeignKeyName')
+            ? $relation->getForeignKeyName()
+            : $relation->getPlainForeignKey()
+        ;
     }
 
     /**

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -471,7 +471,7 @@ abstract class NamedFormElement extends FormElement
                         case HasOne::class:
                         case MorphOne::class:
                             $relatedModel = $relationObject->getRelated()->newInstance();
-                            $relatedModel->setAttribute($relationObject->getPlainForeignKey(), $relationObject->getParentKey());
+                            $relatedModel->setAttribute($relationObject->getForeignKeyName(), $relationObject->getParentKey());
                             $model->setRelation($relation, $relatedModel);
                             break;
                     }

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -496,8 +496,7 @@ abstract class NamedFormElement extends FormElement
     {
         return method_exists($relation, 'getForeignKeyName')
             ? $relation->getForeignKeyName()
-            : $relation->getPlainForeignKey()
-        ;
+            : $relation->getPlainForeignKey();
     }
 
     /**


### PR DESCRIPTION
Call to undefined method Illuminate\Database\Query\Builder::getPlainForeignKey()

Исправление названия метода для получения имени ключа, смотри коммит https://github.com/laravel/framework/commit/294c006288ee182eeddf3c6deb23a35032a9219d