### PR TITLE
Add getNavigation & getNavigationPage methods

### DIFF
--- a/src/Model/ModelConfigurationManager.php
+++ b/src/Model/ModelConfigurationManager.php
@@ -471,6 +471,14 @@ abstract class ModelConfigurationManager implements ModelConfigurationInterface
     }
 
     /**
+     * @return Navigation
+     */
+    public function getNavigation()
+    {
+        return $this->app['sleeping_owl.navigation'];
+    }
+
+    /**
      * @param int $priority
      * @param string|\Closure|BadgeInterface $badge
      *
@@ -480,9 +488,18 @@ abstract class ModelConfigurationManager implements ModelConfigurationInterface
     {
         $page = $this->makePage($priority, $badge);
 
-        $this->app['sleeping_owl.navigation']->addPage($page);
+        $this->getNavigation()->addPage($page);
 
         return $page;
+    }
+
+    /**
+     * @param $page_id
+     * @return \KodiComponents\Navigation\Contracts\PageInterface|null
+     */
+    public function getNavigationPage($page_id)
+    {
+        return $this->getNavigation()->getPages()->findById($page_id);
     }
 
     /**


### PR DESCRIPTION
Используется для поиска нужной секции навигации и добавления в нее элементов меню
```
    /**
     * Initialize class.
     */
    public function initialize()
    {
        /* @var Page $navigation */
        if( $navigation = $this->getNavigationPage('users') ) {
            $navigation->addPage(
                (new Page(Permission::class))->setIcon('fa fa-group')->setPriority(300)
            );
        }
    }
```