### PR TITLE
[DisplayDatatablesAsync] offset and limit should be int

### DIFF
--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -205,7 +205,7 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
             return;
         }
 
-        $query->offset((int)$offset)->limit((int)$limit);
+        $query->offset((int) $offset)->limit((int) $limit);
     }
 
     /**

--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -205,7 +205,7 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
             return;
         }
 
-        $query->offset($offset)->limit($limit);
+        $query->offset((int)$offset)->limit((int)$limit);
     }
 
     /**


### PR DESCRIPTION
That fix allow to use DisplayDatatablesAsync with different laravel equivalent drivers (at least with jenssegers/mongodb)
Also laravel expected int type for that two methods  https://github.com/laravel/framework/blob/5.4/src/Illuminate/Database/Query/Builder.php#L1486