### PR TITLE
Change order of attributes in \Gate::allows call

### DIFF
--- a/src/Model/ModelConfigurationManager.php
+++ b/src/Model/ModelConfigurationManager.php
@@ -308,7 +308,7 @@ abstract class ModelConfigurationManager implements ModelConfigurationInterface
             return true;
         }
 
-        return \Gate::allows($action, [$this, $model]);
+        return \Gate::allows($action, [$model, $this]);
     }
 
     /**


### PR DESCRIPTION
Change order of arguments in \Gate::allows call because Gate expect 0-indexed argument to be key for policy not a Section