### PR TITLE
Использование setHtmlAttribute('id', 'someID') для wysyswig

### DIFF
--- a/resources/views/default/form/element/wysiwyg.blade.php
+++ b/resources/views/default/form/element/wysiwyg.blade.php
@@ -1,11 +1,11 @@
 @push('footer-scripts')
 <script>
-    Admin.WYSIWYG.switchOn('{{ $name }}', '{{ $editor }}', {!! $parameters !!})
+    Admin.WYSIWYG.switchOn('{{ $id }}', '{{ $editor }}', {!! $parameters !!})
 </script>
 @endpush
 
 <div class="form-group form-element-wysiwyg {{ $errors->has($name) ? 'has-error' : '' }}">
-    <label for="{{ $name }}" class="control-label">
+    <label for="{{ $id }}" class="control-label">
         {{ $label }}
 
         @if($required)
@@ -17,7 +17,7 @@
 
     {!! Form::textarea($name, $value, [
         'class' => 'form-control',
-        'id' => $name
+        'id' => $id
     ]) !!}
 
     @include(app('sleeping_owl.template')->getViewPath('form.element.partials.errors'))

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -176,7 +176,7 @@ abstract class NamedFormElement extends FormElement
         $messages = parent::getValidationMessages();
 
         foreach ($messages as $rule => $message) {
-            $messages[$this->getName() . '.' . $rule] = $message;
+            $messages[$this->getName().'.'.$rule] = $message;
             unset($messages[$rule]);
         }
 
@@ -221,9 +221,9 @@ abstract class NamedFormElement extends FormElement
             $model = $this->resolvePath();
             $table = $model->getTable();
 
-            $rule = 'unique:' . $table . ',' . $this->getModelAttributeKey();
+            $rule = 'unique:'.$table.','.$this->getModelAttributeKey();
             if ($model->exists) {
-                $rule .= ',' . $model->getKey();
+                $rule .= ','.$model->getKey();
             }
         }
         unset($rule);
@@ -379,8 +379,8 @@ abstract class NamedFormElement extends FormElement
                     break;
                 } elseif (is_null($relatedModel)) {
                     throw new LogicException("Field [{$path}] can't be mapped to relations of model "
-                                             . get_class($model)
-                                             . '. Probably some dot delimeted segment is not a supported relation type');
+                                             .get_class($model)
+                                             .'. Probably some dot delimeted segment is not a supported relation type');
                 }
             }
 

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -93,6 +93,42 @@ abstract class NamedFormElement extends FormElement
     }
 
     /**
+     * @param string|null $message
+     *
+     * @return $this
+     */
+    public function required($message = null)
+    {
+        $this->addValidationRule('required', $message);
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $message
+     *
+     * @return $this
+     */
+    public function unique($message = null)
+    {
+        $this->addValidationRule('_unique');
+
+        if (!is_null($message)) {
+            $this->addValidationMessage('unique', $message);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValidationLabels()
+    {
+        return [$this->getPath() => $this->getLabel()];
+    }
+
+    /**
      * @return string
      */
     public function getPath()
@@ -108,26 +144,6 @@ abstract class NamedFormElement extends FormElement
     public function setPath($path)
     {
         $this->path = $path;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return $this
-     */
-    public function setName($name)
-    {
-        $this->name = $name;
 
         return $this;
     }
@@ -153,98 +169,6 @@ abstract class NamedFormElement extends FormElement
     }
 
     /**
-     * @return string
-     */
-    public function getModelAttributeKey()
-    {
-        return $this->modelAttributeKey;
-    }
-
-    /**
-     * @param string $key
-     *
-     * @return $this
-     */
-    public function setModelAttributeKey($key)
-    {
-        $this->modelAttributeKey = $key;
-
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getDefaultValue()
-    {
-        return $this->defaultValue;
-    }
-
-    /**
-     * @param mixed $defaultValue
-     *
-     * @return $this
-     */
-    public function setDefaultValue($defaultValue)
-    {
-        $this->defaultValue = $defaultValue;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getHelpText()
-    {
-        if ($this->helpText instanceof Htmlable) {
-            return $this->helpText->toHtml();
-        }
-
-        return $this->helpText;
-    }
-
-    /**
-     * @param string|Htmlable $helpText
-     *
-     * @return $this
-     */
-    public function setHelpText($helpText)
-    {
-        $this->helpText = $helpText;
-
-        return $this;
-    }
-
-    /**
-     * @param string|null $message
-     *
-     * @return $this
-     */
-    public function required($message = null)
-    {
-        $this->addValidationRule('required', $message);
-
-        return $this;
-    }
-
-    /**
-     * @param string|null $message
-     *
-     * @return $this
-     */
-    public function unique($message = null)
-    {
-        $this->addValidationRule('_unique');
-
-        if (! is_null($message)) {
-            $this->addValidationMessage('unique', $message);
-        }
-
-        return $this;
-    }
-
-    /**
      * @return array
      */
     public function getValidationMessages()
@@ -260,11 +184,23 @@ abstract class NamedFormElement extends FormElement
     }
 
     /**
-     * @return array
+     * @return string
      */
-    public function getValidationLabels()
+    public function getName()
     {
-        return [$this->getPath() => $this->getLabel()];
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -339,67 +275,23 @@ abstract class NamedFormElement extends FormElement
     }
 
     /**
-     * @param \Illuminate\Http\Request $request
-     *
-     * @return array|string
+     * @return string
      */
-    public function getValueFromRequest(\Illuminate\Http\Request $request)
+    public function getModelAttributeKey()
     {
-        if ($request->hasSession() && ! is_null($value = $request->old($this->getPath()))) {
-            return $value;
-        }
-
-        return $request->input($this->getPath());
+        return $this->modelAttributeKey;
     }
 
     /**
-     * @return mixed
+     * @param string $key
+     *
+     * @return $this
      */
-    public function getValueFromModel()
+    public function setModelAttributeKey($key)
     {
-        if (! is_null($value = $this->getValueFromRequest(request()))) {
-            return $value;
-        }
+        $this->modelAttributeKey = $key;
 
-        $model = $this->getModel();
-        $path = $this->getPath();
-        $value = $this->getDefaultValue();
-
-        if (is_null($model) or ! $model->exists) {
-            return $value;
-        }
-
-        $relations = explode('.', $path);
-        $count = count($relations);
-
-        if ($count === 1) {
-            $attribute = $model->getAttribute($this->getModelAttributeKey());
-
-            if (! empty($attribute) || $attribute === 0 || is_null($value)) {
-                return $attribute;
-            }
-        }
-
-        foreach ($relations as $relation) {
-            if ($model->{$relation} instanceof Model) {
-                $model = $model->{$relation};
-                continue;
-            }
-
-            if ($count === 2) {
-                $attribute = $model->getAttribute($relation);
-
-                if (! empty($attribute) or is_null($value)) {
-                    return $attribute;
-                }
-            }
-
-            if (is_null($this->getDefaultValue())) {
-                throw new LogicException("Can not fetch value for field '{$path}'. Probably relation definition is incorrect");
-            }
-        }
-
-        return $value;
+        return $this;
     }
 
     /**
@@ -500,30 +392,6 @@ abstract class NamedFormElement extends FormElement
     }
 
     /**
-     * Field->mutateValue(function($value) {
-     *     return bcrypt($value);
-     * }).
-     *
-     * @param \Closure $mutator
-     *
-     * @return $this
-     */
-    public function mutateValue(\Closure $mutator)
-    {
-        $this->mutator = $mutator;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function hasMutator()
-    {
-        return is_callable($this->mutator);
-    }
-
-    /**
      * @param mixed $value
      *
      * @return mixed
@@ -538,14 +406,38 @@ abstract class NamedFormElement extends FormElement
     }
 
     /**
+     * @return bool
+     */
+    public function hasMutator()
+    {
+        return is_callable($this->mutator);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return array|string
+     */
+    public function getValueFromRequest(\Illuminate\Http\Request $request)
+    {
+        if ($request->hasSession()
+            && !is_null($value = $request->old($this->getPath()))
+        ) {
+            return $value;
+        }
+
+        return $request->input($this->getPath());
+    }
+
+    /**
      * @return array
      */
     public function toArray()
     {
         $attributes = $this->getHtmlAttributes();
         $set = [
+            'id' => isset($attributes['id']) ? $attributes['id'] : $this->getName(),
             'name' => $this->getName(),
-            'id'   => isset($attributes['id']) ? $attributes['id'] : $this->getName(),
         ];
 
         $this->setHtmlAttributes($set);
@@ -560,5 +452,115 @@ abstract class NamedFormElement extends FormElement
             'helpText' => $this->getHelpText(),
             'required' => in_array('required', $this->validationRules),
         ]);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValueFromModel()
+    {
+        if (!is_null($value = $this->getValueFromRequest(request()))) {
+            return $value;
+        }
+
+        $model = $this->getModel();
+        $path = $this->getPath();
+        $value = $this->getDefaultValue();
+
+        if (is_null($model) or !$model->exists) {
+            return $value;
+        }
+
+        $relations = explode('.', $path);
+        $count = count($relations);
+
+        if ($count === 1) {
+            $attribute = $model->getAttribute($this->getModelAttributeKey());
+
+            if (!empty($attribute) || $attribute === 0 || is_null($value)) {
+                return $attribute;
+            }
+        }
+
+        foreach ($relations as $relation) {
+            if ($model->{$relation} instanceof Model) {
+                $model = $model->{$relation};
+                continue;
+            }
+
+            if ($count === 2) {
+                $attribute = $model->getAttribute($relation);
+
+                if (!empty($attribute) or is_null($value)) {
+                    return $attribute;
+                }
+            }
+
+            if (is_null($this->getDefaultValue())) {
+                throw new LogicException("Can not fetch value for field '{$path}'. Probably relation definition is incorrect");
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDefaultValue()
+    {
+        return $this->defaultValue;
+    }
+
+    /**
+     * @param mixed $defaultValue
+     *
+     * @return $this
+     */
+    public function setDefaultValue($defaultValue)
+    {
+        $this->defaultValue = $defaultValue;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHelpText()
+    {
+        if ($this->helpText instanceof Htmlable) {
+            return $this->helpText->toHtml();
+        }
+
+        return $this->helpText;
+    }
+
+    /**
+     * @param string|Htmlable $helpText
+     *
+     * @return $this
+     */
+    public function setHelpText($helpText)
+    {
+        $this->helpText = $helpText;
+
+        return $this;
+    }
+
+    /**
+     * Field->mutateValue(function($value) {
+     *     return bcrypt($value);
+     * }).
+     *
+     * @param \Closure $mutator
+     *
+     * @return $this
+     */
+    public function mutateValue(\Closure $mutator)
+    {
+        $this->mutator = $mutator;
+
+        return $this;
     }
 }

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -542,13 +542,16 @@ abstract class NamedFormElement extends FormElement
      */
     public function toArray()
     {
-        $this->setHtmlAttributes([
-            'id' => $this->getName(),
+        $attributes = $this->getHtmlAttributes();
+        $set = [
             'name' => $this->getName(),
-        ]);
+            'id'   => isset($attributes['id']) ? $attributes['id'] : $this->getName(),
+        ];
+
+        $this->setHtmlAttributes($set);
 
         return array_merge(parent::toArray(), [
-            'id' => $this->getName(),
+            'id' => $set['id'],
             'value' => $this->getValueFromModel(),
             'name' => $this->getName(),
             'path' => $this->getPath(),

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -52,7 +52,7 @@ abstract class NamedFormElement extends FormElement
     protected $mutator;
 
     /**
-     * @param string $path
+     * @param string      $path
      * @param string|null $label
      *
      * @throws FormElementException
@@ -113,7 +113,7 @@ abstract class NamedFormElement extends FormElement
     {
         $this->addValidationRule('_unique');
 
-        if (!is_null($message)) {
+        if (! is_null($message)) {
             $this->addValidationMessage('unique', $message);
         }
 
@@ -176,7 +176,7 @@ abstract class NamedFormElement extends FormElement
         $messages = parent::getValidationMessages();
 
         foreach ($messages as $rule => $message) {
-            $messages[$this->getName().'.'.$rule] = $message;
+            $messages[$this->getName() . '.' . $rule] = $message;
             unset($messages[$rule]);
         }
 
@@ -221,9 +221,9 @@ abstract class NamedFormElement extends FormElement
             $model = $this->resolvePath();
             $table = $model->getTable();
 
-            $rule = 'unique:'.$table.','.$this->getModelAttributeKey();
+            $rule = 'unique:' . $table . ',' . $this->getModelAttributeKey();
             if ($model->exists) {
-                $rule .= ','.$model->getKey();
+                $rule .= ',' . $model->getKey();
             }
         }
         unset($rule);
@@ -251,7 +251,9 @@ abstract class NamedFormElement extends FormElement
                 return $model;
             }
 
-            if ($model->exists && ($value = $model->getAttribute($relation)) instanceof Model) {
+            if ($model->exists
+                && ($value = $model->getAttribute($relation)) instanceof Model
+            ) {
                 $model = $value;
 
                 $count--;
@@ -309,7 +311,7 @@ abstract class NamedFormElement extends FormElement
     }
 
     /**
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return void
      */
@@ -358,12 +360,15 @@ abstract class NamedFormElement extends FormElement
 
                     switch (get_class($relationObject)) {
                         case BelongsTo::class:
-                            $relationObject->associate($relatedModel = $relationObject->getRelated());
+                            $relationObject->associate(
+                                $relatedModel = $relationObject->getRelated());
                             break;
                         case HasOne::class:
                         case MorphOne::class:
-                            $relatedModel = $relationObject->getRelated()->newInstance();
-                            $relatedModel->setAttribute($this->getForeignKeyNameFromRelation($relationObject), $relationObject->getParentKey());
+                            $relatedModel =
+                                $relationObject->getRelated()->newInstance();
+                            $relatedModel->setAttribute($this->getForeignKeyNameFromRelation($relationObject),
+                                $relationObject->getParentKey());
                             $model->setRelation($relation, $relatedModel);
                             break;
                     }
@@ -373,8 +378,9 @@ abstract class NamedFormElement extends FormElement
                 if ($i === $count) {
                     break;
                 } elseif (is_null($relatedModel)) {
-                    throw new LogicException("Field [{$path}] can't be mapped to relations of model ".get_class($model)
-                        .'. Probably some dot delimeted segment is not a supported relation type');
+                    throw new LogicException("Field [{$path}] can't be mapped to relations of model "
+                                             . get_class($model)
+                                             . '. Probably some dot delimeted segment is not a supported relation type');
                 }
             }
 
@@ -421,7 +427,7 @@ abstract class NamedFormElement extends FormElement
     public function getValueFromRequest(\Illuminate\Http\Request $request)
     {
         if ($request->hasSession()
-            && !is_null($value = $request->old($this->getPath()))
+            && ! is_null($value = $request->old($this->getPath()))
         ) {
             return $value;
         }
@@ -436,21 +442,23 @@ abstract class NamedFormElement extends FormElement
     {
         $attributes = $this->getHtmlAttributes();
         $set = [
-            'id' => isset($attributes['id']) ? $attributes['id'] : $this->getName(),
+            'id'   => isset($attributes['id']) ? $attributes['id']
+                : $this->getName(),
             'name' => $this->getName(),
         ];
 
         $this->setHtmlAttributes($set);
 
         return array_merge(parent::toArray(), [
-            'id' => $set['id'],
-            'value' => $this->getValueFromModel(),
-            'name' => $this->getName(),
-            'path' => $this->getPath(),
-            'label' => $this->getLabel(),
-            'attributes'=> $this instanceof Select ? $this->getHtmlAttributes() : $this->htmlAttributesToString(),
-            'helpText' => $this->getHelpText(),
-            'required' => in_array('required', $this->validationRules),
+            'id'         => $set['id'],
+            'value'      => $this->getValueFromModel(),
+            'name'       => $this->getName(),
+            'path'       => $this->getPath(),
+            'label'      => $this->getLabel(),
+            'attributes' => $this instanceof Select ? $this->getHtmlAttributes()
+                : $this->htmlAttributesToString(),
+            'helpText'   => $this->getHelpText(),
+            'required'   => in_array('required', $this->validationRules),
         ]);
     }
 
@@ -459,7 +467,7 @@ abstract class NamedFormElement extends FormElement
      */
     public function getValueFromModel()
     {
-        if (!is_null($value = $this->getValueFromRequest(request()))) {
+        if (! is_null($value = $this->getValueFromRequest(request()))) {
             return $value;
         }
 
@@ -467,7 +475,7 @@ abstract class NamedFormElement extends FormElement
         $path = $this->getPath();
         $value = $this->getDefaultValue();
 
-        if (is_null($model) or !$model->exists) {
+        if (is_null($model) or ! $model->exists) {
             return $value;
         }
 
@@ -477,7 +485,7 @@ abstract class NamedFormElement extends FormElement
         if ($count === 1) {
             $attribute = $model->getAttribute($this->getModelAttributeKey());
 
-            if (!empty($attribute) || $attribute === 0 || is_null($value)) {
+            if (! empty($attribute) || $attribute === 0 || is_null($value)) {
                 return $attribute;
             }
         }
@@ -491,7 +499,7 @@ abstract class NamedFormElement extends FormElement
             if ($count === 2) {
                 $attribute = $model->getAttribute($relation);
 
-                if (!empty($attribute) or is_null($value)) {
+                if (! empty($attribute) or is_null($value)) {
                     return $attribute;
                 }
             }


### PR DESCRIPTION
В мультиформах из одной таблицы одно и то-же поле для различных целей должно быть text, image, wysywig. Но т.к. wysyswig присасывается по id, то он всегда в одном экземпляре и самое первое поле, т.к. все поля имею один id. Конструкция вида 
`AdminFormElement::wysiwyg('value', $description)->setHtmlAttribute('id', $key)` теперь работает для wysywig.