### PR TITLE
Использование join в колбеке при поиске, через setSearchOuterCallback

### DIFF
--- a/src/Contracts/Display/ColumnMetaInterface.php
+++ b/src/Contracts/Display/ColumnMetaInterface.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
  * Interface ColumnMetaInterface.
  *
  * @method onSearch(NamedColumnInterface $column, Builder $query, $queryString)
+ * @method onSearchOuter(NamedColumnInterface $column, Builder $query, $queryString)
  * @method onFilterSearch(NamedColumnInterface $column, Builder $query, $queryString, $queryParams)
  * @method onOrderBy(NamedColumnInterface $column, Builder $query, $direction)
  */

--- a/src/Display/Column/Filter.php
+++ b/src/Display/Column/Filter.php
@@ -80,14 +80,15 @@ class Filter extends NamedColumn
      */
     public function getUrl()
     {
-        request()->merge([
+        $request = clone request();
+
+        $request->merge([
             $this->getName() => $this->getValue(),
         ]);
 
         return app('sleeping_owl')
             ->getModel($this->getRelatedModel())
-            ->getDisplayUrl(request()->all());
-    }
+            ->getDisplayUrl($request->all());    }
 
     /**
      * Check if filter applies to the current model.

--- a/src/Display/Column/Filter.php
+++ b/src/Display/Column/Filter.php
@@ -80,15 +80,14 @@ class Filter extends NamedColumn
      */
     public function getUrl()
     {
-        $request = clone request();
-
-        $request->merge([
+        request()->merge([
             $this->getName() => $this->getValue(),
         ]);
 
         return app('sleeping_owl')
             ->getModel($this->getRelatedModel())
-            ->getDisplayUrl($request->all());    }
+            ->getDisplayUrl(request()->all());
+    }
 
     /**
      * Check if filter applies to the current model.

--- a/src/Display/Column/NamedColumn.php
+++ b/src/Display/Column/NamedColumn.php
@@ -20,6 +20,11 @@ abstract class NamedColumn extends TableColumn implements NamedColumnInterface
     /**
      * @var \Closure
      */
+    protected $searchOuterCallback = null;
+
+    /**
+     * @var \Closure
+     */
     protected $orderCallback = null;
 
     /**
@@ -126,6 +131,17 @@ abstract class NamedColumn extends TableColumn implements NamedColumnInterface
      * @param \Closure $callable
      * @return $this
      */
+    public function setSearchOuterCallback(\Closure $callable)
+    {
+        $this->searchOuterCallback = $callable;
+
+        return $this;
+    }
+
+    /**
+     * @param \Closure $callable
+     * @return $this
+     */
     public function setFilterCallback(\Closure $callable)
     {
         $this->filterCallback = $callable;
@@ -147,6 +163,14 @@ abstract class NamedColumn extends TableColumn implements NamedColumnInterface
     public function getSearchCallback()
     {
         return $this->searchCallback;
+    }
+
+    /**
+     * @return \Closure
+     */
+    public function getSearchOuterCallback()
+    {
+        return $this->searchOuterCallback;
     }
 
     /**

--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -107,7 +107,7 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
             $this->setHtmlAttribute('data-display-search', 1);
         }
 
-        if($this->getDisplayLength()){
+        if ($this->getDisplayLength()){
             $this->setHtmlAttribute('data-display-dtlength', 1);
         }
     }

--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -256,7 +256,6 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
         $columns = $this->getColumns()->all();
 
         $query->where(function ($query) use ($search, $columns) {
-
             foreach ($columns as $column) {
                 if (in_array(get_class($column), $this->searchableColumns)) {
                     if ($column instanceof NamedColumnInterface) {

--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -107,14 +107,12 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
             $this->setHtmlAttribute('data-display-search', 1);
         }
 
-        if ($this->getDisplayLength()){
+        if ($this->getDisplayLength()) {
             $this->setHtmlAttribute('data-display-dtlength', 1);
         }
     }
 
-
     /**
-     *
      * @param bool $length
      * @return $this
      */


### PR DESCRIPTION
Сейчас в задаваемом через setSearchCallback() колбеке можно использовать только методы where, orWhere. Все остальные eloquent методы не сработают, так как все колбеки, задаваемые через setSearchCallback(), вызывается внутри одной общей секции **where** заготовки запроса (*src/Display/DisplayDatatablesAsync.php, метод applySearch()*).

Это неудобно, т.к. в случае использования в столбцах datatablesAsync значений из внешних таблиц и желании осуществлять поиск по ним, нужно подключать эти самые внешние таблицы через join, однако внутри задаваемого через setSearchCallback() колбека этого сделать не получится, и приходится придумывать костыли внутри setApply() с доп. проверками, например так:
```
$display->setColumns([
    AdminColumn::text('id'),
    AdminColumn::text('title'),
    AdminColumn::text('city.short_title')->setLabel('Город')
        ->setSearchCallback(function($column, $query, $search){
            $query->orWhere('city.full_title', 'LIKE', '%' . $search . '%');
        }),
]);
$display->setApply(function($query) {
    if (Input::get('search.value')) {
        $query->leftJoin('cities', 'cities.id', '=', 'company.city_id');
    }
});
```

В качестве решения предлагаю в дополнение к setSearchCallback() добавить метод setSearchOuterCallback(), который позволяет задавать колбеки на поиск, которые будут вызываться "снаружи" общей секции **where** заготовки запроса.

Данный функционал следует использовать с осторожностью, т.к. все запросы внутри этих колбеков не будут объединены в общую секцию **where**, и это может привести к неожиданным результатам.