### PR TITLE
Сброс номера страницы при слиянии параметров запроса при фильтрации

### DIFF
--- a/src/Display/Column/Filter.php
+++ b/src/Display/Column/Filter.php
@@ -84,6 +84,7 @@ class Filter extends NamedColumn
 
         $request->merge([
             $this->getName() => $this->getValue(),
+            'page' => 1,
         ]);
 
         return app('sleeping_owl')


### PR DESCRIPTION
Чтобы находясь, например, на десятой странице списка, при нажатии на ссылку-фильтр переходить на первую страницу списка с только что примененным условием фильтрации, а не на десятую, которая может оказаться пустой.
refs #557