### PR TITLE
Админка и Elouqent observer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## [Unreleased] (Only in `development` branch)
+ * [Feature] Добавлена обработка событий Eloquent Observer при сохранении, удалении, восстановлении записи.
  * [Bug-fix] Не выводились метки для редактируемых колонок. Теперь можно делать так: `AdminColumnEditable::text('fieldName', 'ColumnLabel')` и `AdminColumnEditable::checkbox('fieldName', 'CheckedLabel', 'UncheckedLabel', 'ColumnLabel')`, или по-старинке `->setLabel('ColumnLabel')`
  * [Bug-Fix] Теперь afterSave у MultiSelect учитывает ValueSkipped у элемента формы
  * [Feature] Добавлены SweetAlert2 к массовым действиям - контроллер который отвечает за получение и обработку ID должен возвращать json-data

--- a/src/Form/FormDefault.php
+++ b/src/Form/FormDefault.php
@@ -318,7 +318,9 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
             return false;
         }
 
-        $model->save();
+        if($model->save() === false) {
+            return false;
+        }
 
         $this->saveHasOneRelations($model);
 

--- a/src/Form/FormDefault.php
+++ b/src/Form/FormDefault.php
@@ -318,7 +318,7 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
             return false;
         }
 
-        if($model->save() === false) {
+        if ($model->save() === false) {
             return false;
         }
 

--- a/src/Http/Controllers/AdminController.php
+++ b/src/Http/Controllers/AdminController.php
@@ -419,7 +419,9 @@ class AdminController extends Controller
             return redirect()->back();
         }
 
-        $model->getRepository()->delete($id);
+        if ($model->getRepository()->delete($id) === false) {
+            return redirect()->back();
+        }
 
         $model->fireEvent('deleted', false, $item);
 
@@ -454,7 +456,9 @@ class AdminController extends Controller
             return redirect()->back();
         }
 
-        $model->getRepository()->forceDelete($id);
+        if ($model->getRepository()->forceDelete($id)) {
+            return redirect()->back();
+        }
 
         $model->fireEvent('destroyed', false, $item);
 
@@ -489,7 +493,9 @@ class AdminController extends Controller
             return redirect()->back();
         }
 
-        $model->getRepository()->restore($id);
+        if ($model->getRepository()->restore($id) === false) {
+            return redirect()->back();
+        }
 
         $model->fireEvent('restored', false, $item);
 

--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -161,30 +161,36 @@ class BaseRepository implements RepositoryInterface
      * Delete model instance by id.
      *
      * @param int $id
+     *
+     * @return bool|null
      */
     public function delete($id)
     {
-        $this->find($id)->delete();
+        return $this->find($id)->delete();
     }
 
     /**
      * Permanently delete model instance by id.
      *
      * @param int $id
+     *
+     * @return bool|null
      */
     public function forceDelete($id)
     {
-        $this->findOnlyTrashed($id)->forceDelete();
+        return $this->findOnlyTrashed($id)->forceDelete();
     }
 
     /**
      * Restore model instance by id.
      *
      * @param int $id
+     *
+     * @return bool|null
      */
     public function restore($id)
     {
-        $this->findOnlyTrashed($id)->restore();
+        return $this->findOnlyTrashed($id)->restore();
     }
 
     /**


### PR DESCRIPTION
Возможно так и задумано изначально (специально), но как обнаружилось при удалении записи не анализируется ответ стандартного обсервера модели. Только внутренние события, определенные админкой. Что возможно и логично, но не очень хорошо.

Добавлена реакция на save, delete, forceDelete, restore. Если методы модели возвращают false - работа методов админки прекращаются.