### PR TITLE
datatable support customize unsearchable columns

### DIFF
--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -73,6 +73,11 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
     ];
 
     /**
+     * @var array
+     */
+    protected $unsearchableColumns = [];
+
+    /**
      * DisplayDatatablesAsync constructor.
      *
      * @param string|null $name
@@ -191,6 +196,17 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
     }
 
     /**
+     * @param array $columns
+     *
+     * @return $this
+     */
+    public function setUnsearchableColumns(array $columns)
+    {
+        $this->unsearchableColumns = $columns;
+        return $this;
+    }
+
+    /**
      * Render async request.
      *
      * @param \Illuminate\Http\Request $request
@@ -257,7 +273,8 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
             $columns = $this->getColumns()->all();
 
             foreach ($columns as $column) {
-                if (in_array(get_class($column), $this->searchableColumns)) {
+                if (in_array(get_class($column), $this->searchableColumns) &&
+                    !in_array($column->getName(), $this->unsearchableColumns)) {
                     if ($column instanceof NamedColumnInterface) {
                         if (($metaInstance = $column->getMetaData()) instanceof ColumnMetaInterface) {
                             if (method_exists($metaInstance, 'onSearch')) {

--- a/src/Display/DisplayDatatablesAsync.php
+++ b/src/Display/DisplayDatatablesAsync.php
@@ -203,6 +203,7 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
     public function setUnsearchableColumns(array $columns)
     {
         $this->unsearchableColumns = $columns;
+
         return $this;
     }
 
@@ -274,7 +275,7 @@ class DisplayDatatablesAsync extends DisplayDatatables implements WithRoutesInte
 
             foreach ($columns as $column) {
                 if (in_array(get_class($column), $this->searchableColumns) &&
-                    !in_array($column->getName(), $this->unsearchableColumns)) {
+                    ! in_array($column->getName(), $this->unsearchableColumns)) {
                     if ($column instanceof NamedColumnInterface) {
                         if (($metaInstance = $column->getMetaData()) instanceof ColumnMetaInterface) {
                             if (method_exists($metaInstance, 'onSearch')) {


### PR DESCRIPTION
for some columns that we don't want to be searchable, we can just change `unsearchableColumns` property

e.g
```
AdminDisplay::datatablesAsync()->setDisplaySearch(true)->setUnsearchableColumns(['category.name', 'fullName'])
```