### PR TITLE
Исправлена ошибка парсинга данных изображений.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## [Unreleased] (Only in `development` branch)
+ * [Bug-Fix] Ошибка при получении данных для `AdminFormElement::images` из модели (`storeAsComaSeparatedValue()`) или если возникла ошибка сохранения формы.
  * [Bug-fix] Не выводились метки для редактируемых колонок. Теперь можно делать так: `AdminColumnEditable::text('fieldName', 'ColumnLabel')` и `AdminColumnEditable::checkbox('fieldName', 'CheckedLabel', 'UncheckedLabel', 'ColumnLabel')`, или по-старинке `->setLabel('ColumnLabel')`
  * [Bug-Fix] Теперь afterSave у MultiSelect учитывает ValueSkipped у элемента формы
  * [Feature] Добавлены SweetAlert2 к массовым действиям - контроллер который отвечает за получение и обработку ID должен возвращать json-data

--- a/src/Form/Element/Images.php
+++ b/src/Form/Element/Images.php
@@ -41,16 +41,18 @@ class Images extends Image
      */
     public function getValueFromModel()
     {
-        $value = parent::getValueFromModel();
+        $images = $value = parent::getValueFromModel();
+
         if (is_null($value)) {
-            $value = [];
+            $images = [];
+        } else if (is_string($value)
+                   && (($images = json_decode($value)) === false
+                       || is_null($images))
+        ) {
+            $images = preg_split('/,/', $value, -1, PREG_SPLIT_NO_EMPTY);
         }
 
-        if (is_string($value) && ($value = json_decode($value)) === false) {
-            $value = preg_split('/,/', $value, -1, PREG_SPLIT_NO_EMPTY);
-        }
-
-        return $value;
+        return $images;
     }
 
     /**

--- a/src/Form/Element/Images.php
+++ b/src/Form/Element/Images.php
@@ -45,7 +45,7 @@ class Images extends Image
 
         if (is_null($value)) {
             $images = [];
-        } else if (is_string($value)
+        } elseif (is_string($value)
                    && (($images = json_decode($value)) === false
                        || is_null($images))
         ) {


### PR DESCRIPTION
В методе `getValueFromModel()` исправлен парсинг сохраненных ранее изображней как `storeAsComaSeparatedValue()` и парсинг пришедших из формы изображений (если в форме возникла ошибка валидации, они тоже разделены запятой).