### PR TITLE
Timezone added to the DateTime column type using Carbon's timezone() function

### DIFF
--- a/config/sleeping_owl.php
+++ b/config/sleeping_owl.php
@@ -102,6 +102,7 @@ return [
     'datetimeFormat' => 'd.m.Y H:i',
     'dateFormat' => 'd.m.Y',
     'timeFormat' => 'H:i',
+    'timezone' => 'UTC',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Display/Column/DateTime.php
+++ b/src/Display/Column/DateTime.php
@@ -14,6 +14,12 @@ class DateTime extends NamedColumn
     protected $format;
 
     /**
+     * Datetime timezone.
+     * @var string
+     */
+    protected $timezone;
+
+    /**
      * @var string
      */
     protected $view = 'column.datetime';
@@ -44,6 +50,18 @@ class DateTime extends NamedColumn
     }
 
     /**
+     * @return string
+     */
+    public function getTimezone()
+    {
+        if (is_null($this->timezone)) {
+            $this->timezone = config('sleeping_owl.timezone');
+        }
+
+        return $this->timezone;
+    }
+
+    /**
      * @param string $format
      *
      * @return $this
@@ -51,6 +69,18 @@ class DateTime extends NamedColumn
     public function setFormat($format)
     {
         $this->format = $format;
+
+        return $this;
+    }
+
+    /**
+     * @param string $timezone
+     *
+     * @return $this
+     */
+    public function setTimezone($timezone)
+    {
+        $this->timezone = $timezone;
 
         return $this;
     }
@@ -80,7 +110,7 @@ class DateTime extends NamedColumn
                 $date = Carbon::parse($date);
             }
 
-            $date = $date->format($this->getFormat());
+            $date = $date->timezone($this->getTimezone())->format($this->getFormat());
         }
 
         return $date;

--- a/src/Form/Element/DateTime.php
+++ b/src/Form/Element/DateTime.php
@@ -15,6 +15,11 @@ class DateTime extends NamedFormElement
     protected $format = 'Y-m-d H:i:s';
 
     /**
+     * @var string
+     */
+    protected $timezone;
+
+    /**
      * @var bool
      */
     protected $seconds = false;
@@ -33,6 +38,18 @@ class DateTime extends NamedFormElement
     }
 
     /**
+     * @return string
+     */
+    public function getTimezone()
+    {
+        if (is_null($this->timezone)) {
+            $this->timezone = config('sleeping_owl.timezone');
+        }
+
+        return $this->timezone;
+    }
+
+    /**
      * @param string|null $format
      *
      * @return $this
@@ -40,6 +57,18 @@ class DateTime extends NamedFormElement
     public function setFormat($format)
     {
         $this->format = $format;
+
+        return $this;
+    }
+
+    /**
+     * @param string $timezone
+     *
+     * @return $this
+     */
+    public function setTimezone($timezone)
+    {
+        $this->timezone = $timezone;
 
         return $this;
     }
@@ -83,7 +112,8 @@ class DateTime extends NamedFormElement
     public function setModelAttribute($value)
     {
         $value = ! empty($value)
-            ? Carbon::createFromFormat($this->getPickerFormat(), $value)->format($this->getFormat())
+            ? Carbon::createFromFormat($this->getPickerFormat(), $value, $this->getTimezone())
+                    ->timezone(config('app.timezone'))->format($this->getFormat())
             : null;
 
         parent::setModelAttribute($value);
@@ -125,7 +155,7 @@ class DateTime extends NamedFormElement
      */
     public function setCurrentDate()
     {
-        $this->defaultValue = Carbon::now()->format($this->getFormat());
+        $this->defaultValue = Carbon::now()->timezone($this->getTimezone())->format($this->getFormat());
 
         return $this;
     }
@@ -157,7 +187,7 @@ class DateTime extends NamedFormElement
             }
         }
 
-        return $time->format(
+        return $time->timezone($this->getTimezone())->format(
             $this->getPickerFormat()
         );
     }

--- a/src/Form/Element/Timestamp.php
+++ b/src/Form/Element/Timestamp.php
@@ -24,7 +24,7 @@ class Timestamp extends DateTime
         $value = parent::getValueFromModel();
 
         if (empty($value)) {
-            $value = Carbon::now()->format($this->getFormat());
+            $value = Carbon::now()->timezone($this->getTimezone())->format($this->getFormat());
         }
 
         return $value;


### PR DESCRIPTION
Кейс: приложение работает в UTC, админы сидят в где-нибудь «там», им удобнее смотреть временные метки в своём часовом поясе.

Добавил возможность указать часовой пояс в конфиге, к которому будут приводиться колонки дат, можно использовать локально с помощью **setTimezone()**:

```php
AdminColumn::datetime('date', 'Date')->setTimezone('Asia/Novosibirsk')->setFormat('d.m.Y')
```

Также с элементом формы DateTime:

```php
AdminFormElement::datetime('date', 'Date')->setTimezone('Asia/Novosibirsk')
```

По элементам формы. При выводе в **parseValue()** дата приводится к часовому поясу админки, при установке значения через **setModelAttrbiute()** приводится к часовому поясу приложения следующим образом:

```php
Carbon::createFromFormat($this->getPickerFormat(), $value, $this->getTimezone())
      ->timezone(config('app.timezone'))->format($this->getFormat())
```

Наследуемые Date, Time и Timestamp должны работать как полагается, DateRange пока не понял.