### PR TITLE
Отметить активным только реально Активные табы

### DIFF
--- a/src/Display/DisplayTab.php
+++ b/src/Display/DisplayTab.php
@@ -154,7 +154,9 @@ class DisplayTab implements TabInterface, DisplayInterface, FormInterface
     {
         $this->active = (bool) $active;
 
-        $this->setHtmlAttribute('class', 'active');
+        if ($active) {
+            $this->setHtmlAttribute('class', 'active');
+        }
 
         return $this;
     }


### PR DESCRIPTION
После коммита https://github.com/LaravelRUS/SleepingOwlAdmin/commit/9011dc6a39855e1959036245ea809e496c2ce37f
Все табы стали активными (по-умолчанию) и их нельзя было из-за этого переключать, у активной же табы было два класса active


```
<li role="presentation" class="active active">
<li role="presentation" class="active">
<li role="presentation" class="active">

```
