### PR TITLE
add columnsTotal extension

### DIFF
--- a/resources/views/default/display/extensions/columns_total.blade.php
+++ b/resources/views/default/display/extensions/columns_total.blade.php
@@ -1,0 +1,13 @@
+<{{ $tag }} {!! $attributes !!}>
+    <tr>
+        @foreach ($elements as $element)
+            <td {!! $element->htmlAttributesToString() !!}>
+                @if($element instanceof SleepingOwl\Admin\Display\Link)
+                    <a  {!! $element->attributes() !!} href="{!! $element->getUrl() !!}">{!! $element->getTitle() !!}</a>
+                @else
+                    <{!! $element->getTag() !!} {!!  $element->attributes() !!}>{!! $element->getText() !!}</{!! $element->getTag() !!}>
+                @endif
+            </td>
+        @endforeach
+    </tr>
+</{{ $tag }}>

--- a/src/Display/DisplayTable.php
+++ b/src/Display/DisplayTable.php
@@ -2,14 +2,15 @@
 
 namespace SleepingOwl\Admin\Display;
 
-use Request;
-use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
-use SleepingOwl\Admin\Display\Extension\Columns;
-use SleepingOwl\Admin\Display\Extension\ColumnFilters;
+use Illuminate\Support\Collection;
+use Request;
 use SleepingOwl\Admin\Contracts\Display\ColumnInterface;
 use SleepingOwl\Admin\Contracts\Display\Extension\ColumnFilterInterface;
+use SleepingOwl\Admin\Display\Extension\ColumnFilters;
+use SleepingOwl\Admin\Display\Extension\Columns;
+use SleepingOwl\Admin\Display\Extension\ColumnsTotal;
 
 /**
  * Class DisplayTable.
@@ -61,6 +62,7 @@ class DisplayTable extends Display
 
         $this->extend('columns', new Columns());
         $this->extend('column_filters', new ColumnFilters());
+        $this->extend('columns_total', new ColumnsTotal());
     }
 
     /**

--- a/src/Display/Element.php
+++ b/src/Display/Element.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SleepingOwl\Admin\Display;
+
+use KodiComponents\Support\HtmlAttributes;
+
+class Element
+{
+    use HtmlAttributes;
+    
+    protected $text;
+    protected $tag;
+
+    public function __construct($text, $tag = 'span')
+    {
+        $this->text = $text;
+        $this->tag = $tag;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    public function getTag()
+    {
+        return $this->tag;
+    }
+
+    public function setTag($tag)
+    {
+        $this->tag = $tag;
+    }
+
+    public static function create($text)
+    {
+        return new static($text);
+    }
+
+    public function attributes()
+    {
+        return $this->htmlAttributesToString();
+    }
+}

--- a/src/Display/Extension/ColumnsTotal.php
+++ b/src/Display/Extension/ColumnsTotal.php
@@ -3,9 +3,9 @@
 namespace SleepingOwl\Admin\Display\Extension;
 
 use Illuminate\Support\Collection;
+use SleepingOwl\Admin\Display\Element;
 use KodiComponents\Support\HtmlAttributes;
 use SleepingOwl\Admin\Contracts\Display\Placable;
-use SleepingOwl\Admin\Display\Element;
 
 class ColumnsTotal extends Extension implements Placable
 {
@@ -37,7 +37,7 @@ class ColumnsTotal extends Extension implements Placable
     public function set(array $elements, $columnsNumber = 0)
     {
         array_map(function ($element) {
-            if (!is_object($element)) {
+            if (! is_object($element)) {
                 $element = Element::create($element);
             }
             $this->elements->push($element);

--- a/src/Display/Extension/ColumnsTotal.php
+++ b/src/Display/Extension/ColumnsTotal.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SleepingOwl\Admin\Display\Extension;
+
+use Illuminate\Support\Collection;
+use KodiComponents\Support\HtmlAttributes;
+use SleepingOwl\Admin\Contracts\Display\Placable;
+use SleepingOwl\Admin\Display\Element;
+
+class ColumnsTotal extends Extension implements Placable
+{
+    use HtmlAttributes;
+
+    protected $view = 'display.extensions.columns_total';
+    protected $placement = 'table.header';
+
+    /**
+     * @var Collection
+     */
+    protected $elements;
+
+    public function __construct()
+    {
+        $this->elements = new Collection();
+    }
+
+    public function getPlacement()
+    {
+        return $this->placement;
+    }
+
+    public function getView()
+    {
+        return $this->view;
+    }
+
+    public function set(array $elements, $columnsNumber = 0)
+    {
+        array_map(function ($element) {
+            if (!is_object($element)) {
+                $element = Element::create($element);
+            }
+            $this->elements->push($element);
+        },
+            array_pad($elements, max($columnsNumber, count($elements)), '')
+        );
+
+        return $this;
+    }
+
+    public function toArray()
+    {
+        $this->setHtmlAttribute('class', 'table table-striped');
+
+        return [
+            'elements' => $this->elements,
+            'attributes' => $this->htmlAttributesToString(),
+            'tag' => $this->getPlacement() == 'table.header' ? 'thead' : 'tfoot',
+        ];
+    }
+}


### PR DESCRIPTION
Добавляет возможность вывести строчку в таблице (DisplayTabble), например, для агрегации результатов:
![Пример как выглядит](https://user-images.githubusercontent.com/4217955/29365724-ac4ba3f8-82a0-11e7-9dae-ea1e3ce1c622.jpg)
Пример подключения:
```
$display
            ->set(
                [
                    Statistic::sum('leads')
                ],
                $display->getColumns()->all()->count()
            );
```
Для того, чтобы применить фильтр для текущей query можно сделать следующий запрос:
```
$totalQuery = Statistic::query();
$display->getFilters()->initialize();
$display->getFilters()->modifyQuery($totalQuery);
```
Из **$totalQuery** уже можно скомпоновать агрегированные данные