### PR TITLE
add export to Excel functional for DisplayTable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "kodicms/laravel-assets": "0.*",
     "erusev/parsedown": "1.*",
     "davejamesmiller/laravel-breadcrumbs": "^3.0",
-    "barryvdh/laravel-ide-helper": "^2.4"
+    "barryvdh/laravel-ide-helper": "^2.4",
+    "maatwebsite/excel": "~2.1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.0",

--- a/src/Http/Controllers/ExportController.php
+++ b/src/Http/Controllers/ExportController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SleepingOwl\Admin\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
+use SleepingOwl\Admin\Http\Request\ExportModel;
+
+class ExportController extends Controller
+{
+    public function export(ModelConfigurationInterface $model, ExportModel $export)
+    {
+        $export->setModel($model);
+
+        return $export->handleExport();
+    }
+}

--- a/src/Http/Controllers/ExportController.php
+++ b/src/Http/Controllers/ExportController.php
@@ -3,8 +3,8 @@
 namespace SleepingOwl\Admin\Http\Controllers;
 
 use Illuminate\Routing\Controller;
-use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 use SleepingOwl\Admin\Http\Request\ExportModel;
+use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 
 class ExportController extends Controller
 {

--- a/src/Http/Request/ExportModel.php
+++ b/src/Http/Request/ExportModel.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SleepingOwl\Admin\Http\Request;
+
+use Maatwebsite\Excel\Files\NewExcelFile;
+use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
+
+class ExportModel extends NewExcelFile
+{
+    /** @var  string */
+    protected $filename;
+
+    /** @var  ModelConfigurationInterface */
+    protected $model;
+
+    /**
+     * @return string
+     */
+    public function getFilename()
+    {
+        return $this->filename;
+    }
+
+    /**
+     * @return ModelConfigurationInterface
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    public function setModel(ModelConfigurationInterface $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/src/Http/Request/ExportModel.php
+++ b/src/Http/Request/ExportModel.php
@@ -7,10 +7,10 @@ use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 
 class ExportModel extends NewExcelFile
 {
-    /** @var  string */
+    /** @var string */
     protected $filename;
 
-    /** @var  ModelConfigurationInterface */
+    /** @var ModelConfigurationInterface */
     protected $model;
 
     /**

--- a/src/Http/Request/ExportModelHandler.php
+++ b/src/Http/Request/ExportModelHandler.php
@@ -2,9 +2,9 @@
 
 namespace SleepingOwl\Admin\Http\Request;
 
-use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
-use SleepingOwl\Admin\Display\Column\Control;
 use SleepingOwl\Admin\Display\DisplayTable;
+use SleepingOwl\Admin\Display\Column\Control;
+use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 
 class ExportModelHandler
 {
@@ -14,7 +14,7 @@ class ExportModelHandler
     protected $display;
 
     /**
-     * Initialize DisplayTable
+     * Initialize DisplayTable.
      *
      * @param ModelConfigurationInterface $model
      * @throws \Exception
@@ -24,7 +24,7 @@ class ExportModelHandler
         /** @var DisplayTable $display */
         $display = $model->onDisplay();
 
-        if ( ! $display instanceof DisplayTable) {
+        if (! $display instanceof DisplayTable) {
             throw new \Exception('Display is not instance of "' . DisplayTable::class . '" class');
         }
 
@@ -36,7 +36,7 @@ class ExportModelHandler
     }
 
     /**
-     * Return data array without pagination
+     * Return data array without pagination.
      *
      * @return array
      */
@@ -48,7 +48,7 @@ class ExportModelHandler
             })->map(function ($column) use ($model) {
                 $column->setModel($model);
 
-                if ( ! method_exists($column, 'getModelValue')) {
+                if (! method_exists($column, 'getModelValue')) {
                     return false;
                 }
 
@@ -60,7 +60,7 @@ class ExportModelHandler
     }
 
     /**
-     * Return array of columns header
+     * Return array of columns header.
      *
      * @return array
      */
@@ -83,8 +83,8 @@ class ExportModelHandler
         $filters = $this->display->getFilters()->toArray();
 
         return array_map(function ($filter) {
-                return $filter->getTitle();
-            },
+            return $filter->getTitle();
+        },
             $filters['filters']
         );
     }
@@ -94,7 +94,7 @@ class ExportModelHandler
      */
     protected function getTotalsArray(ModelConfigurationInterface $model)
     {
-        if ( ! method_exists($model, 'getTotalRow')) {
+        if (! method_exists($model, 'getTotalRow')) {
             return [];
         }
 
@@ -128,7 +128,7 @@ class ExportModelHandler
     }
 
     /**
-     * Get data array for write to excel file
+     * Get data array for write to excel file.
      *
      * @return array
      */

--- a/src/Http/Request/ExportModelHandler.php
+++ b/src/Http/Request/ExportModelHandler.php
@@ -3,6 +3,7 @@
 namespace SleepingOwl\Admin\Http\Request;
 
 use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
+use SleepingOwl\Admin\Display\Column\Control;
 use SleepingOwl\Admin\Display\DisplayTable;
 
 class ExportModelHandler
@@ -18,7 +19,7 @@ class ExportModelHandler
      * @param ModelConfigurationInterface $model
      * @throws \Exception
      */
-    protected function initDisplay(ModelConfigurationInterface $model)
+    public function initDisplay(ModelConfigurationInterface $model)
     {
         /** @var DisplayTable $display */
         $display = $model->onDisplay();
@@ -42,7 +43,9 @@ class ExportModelHandler
     protected function getCollectionArray()
     {
         return $this->display->getCollection()->map(function ($model) {
-            return $this->display->getColumns()->all()->map(function ($column) use ($model) {
+            return $this->display->getColumns()->all()->filter(function ($column) {
+                return ! $column instanceof Control;
+            })->map(function ($column) use ($model) {
                 $column->setModel($model);
 
                 if ( ! method_exists($column, 'getModelValue')) {
@@ -63,7 +66,9 @@ class ExportModelHandler
      */
     protected function getHeadersArray()
     {
-        return $this->display->getColumns()->all()->map(function ($column) {
+        return $this->display->getColumns()->all()->filter(function ($column) {
+            return ! $column instanceof Control;
+        })->map(function ($column) {
             $value = $column->getHeader()->getTitle();
 
             return ! is_object($value) ? $value : '';
@@ -127,7 +132,7 @@ class ExportModelHandler
      *
      * @return array
      */
-    protected function getData(ModelConfigurationInterface $model)
+    public function getData(ModelConfigurationInterface $model)
     {
         $data = $this->getCollectionArray();
         $headers = $this->getHeadersArray();

--- a/src/Http/Request/ExportModelHandler.php
+++ b/src/Http/Request/ExportModelHandler.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace SleepingOwl\Admin\Http\Request;
+
+use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
+use SleepingOwl\Admin\Display\DisplayTable;
+
+class ExportModelHandler
+{
+    /**
+     * @var DisplayTable
+     */
+    protected $display;
+
+    /**
+     * Initialize DisplayTable
+     *
+     * @param ModelConfigurationInterface $model
+     * @throws \Exception
+     */
+    protected function initDisplay(ModelConfigurationInterface $model)
+    {
+        /** @var DisplayTable $display */
+        $display = $model->onDisplay();
+
+        if ( ! $display instanceof DisplayTable) {
+            throw new \Exception('Display is not instance of "' . DisplayTable::class . '" class');
+        }
+
+        $display->setModelClass($model->getClass());
+        $display->initialize();
+        $display->disablePagination();
+
+        $this->display = $display;
+    }
+
+    /**
+     * Return data array without pagination
+     *
+     * @return array
+     */
+    protected function getCollectionArray()
+    {
+        return $this->display->getCollection()->map(function ($model) {
+            return $this->display->getColumns()->all()->map(function ($column) use ($model) {
+                $column->setModel($model);
+
+                if ( ! method_exists($column, 'getModelValue')) {
+                    return false;
+                }
+
+                $value = $column->getModelValue();
+
+                return is_object($value) ? $value->__toString() : $value;
+            });
+        })->toArray();
+    }
+
+    /**
+     * Return array of columns header
+     *
+     * @return array
+     */
+    protected function getHeadersArray()
+    {
+        return $this->display->getColumns()->all()->map(function ($column) {
+            $value = $column->getHeader()->getTitle();
+
+            return ! is_object($value) ? $value : '';
+        })->toArray();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getFiltersArray()
+    {
+        $filters = $this->display->getFilters()->toArray();
+
+        return array_map(function ($filter) {
+                return $filter->getTitle();
+            },
+            $filters['filters']
+        );
+    }
+
+    /**
+     * @return array
+     */
+    protected function getTotalsArray(ModelConfigurationInterface $model)
+    {
+        if ( ! method_exists($model, 'getTotalRow')) {
+            return [];
+        }
+
+        return array_pad(
+            forward_static_call([get_class($model), 'getTotalRow'], $this->display),
+            $this->display->getColumns()->all()->count(),
+            ''
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getExcelFileNameFromFilters()
+    {
+        $filtersValue = array_map(function ($filter) {
+            return camel_case(
+                preg_replace('/^.*?\[(.*?)\].*?$/s', '$1', $filter)
+            );
+        },
+            $this->getFiltersArray()
+        );
+
+        $filtersValue = array_filter($filtersValue);
+
+        if (count($filtersValue)) {
+            return implode('-', $filtersValue);
+        }
+
+        return date('Y-m-d H:i:s');
+    }
+
+    /**
+     * Get data array for write to excel file
+     *
+     * @return array
+     */
+    protected function getData(ModelConfigurationInterface $model)
+    {
+        $data = $this->getCollectionArray();
+        $headers = $this->getHeadersArray();
+
+        $result = array_filter(array_merge(
+            [$this->getFiltersArray()],
+            [$headers],
+            $data,
+            [$this->getTotalsArray($model)]
+        ));
+
+        return $result;
+    }
+
+    public function handle(ExportModel $export)
+    {
+        $model = $export->getModel();
+
+        $this->initDisplay($model);
+        $filename = $this->getExcelFileNameFromFilters();
+        $export->setFilename($filename);
+
+        return $export->sheet('sheetName', function ($sheet) use ($model) {
+            $sheet->fromArray($this->getData($model), null, 'A1', false, false);
+        })
+        ->export('xls');
+    }
+}

--- a/src/Http/Request/ExportModelHandler.php
+++ b/src/Http/Request/ExportModelHandler.php
@@ -25,7 +25,7 @@ class ExportModelHandler
         $display = $model->onDisplay();
 
         if (! $display instanceof DisplayTable) {
-            throw new \Exception('Display is not instance of "' . DisplayTable::class . '" class');
+            throw new \Exception('Display is not instance of "'.DisplayTable::class.'" class');
         }
 
         $display->setModelClass($model->getClass());

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -56,4 +56,9 @@ $router->group(['as' => 'admin.', 'namespace' => 'SleepingOwl\Admin\Http\Control
         'as'   => 'wildcard',
         'uses' => 'AdminController@getWildcard',
     ]);
+
+    $router->get('export/{adminModel}', [
+        'as'   => 'export',
+        'uses' => 'ExportController@export',
+    ]);
 });

--- a/tests/Admin/Http/Request/ExportModelHandlerTest.php
+++ b/tests/Admin/Http/Request/ExportModelHandlerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+use Mockery as m;
+use SleepingOwl\Admin\Http\Request\ExportModel;
+use SleepingOwl\Admin\Http\Request\ExportModelHandler;
+use SleepingOwl\Admin\Model\SectionModelConfiguration;
+
+class ExportModelHandlerTest extends TestCase
+{
+    const COLLECTION = [
+        ['field1' => 'test1', 'field2' => 'test2']
+    ];
+
+    const COLUMNS = [
+        'field1' => 'Test1',
+        'field2' => 'Test2'
+    ];
+
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /**
+     * @return SectionModelConfiguration
+     */
+    protected function getSection()
+    {
+        $section = new TestTableSection($this->app);
+        $section->setCollection(
+            $this->transformCollectionToModel(self::COLLECTION)
+        );
+        $section->setColumns($this->getColumns());
+
+        return $section;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getColumns()
+    {
+        return array_map(function ($fieldName, $label) {
+                return \AdminColumn::text($fieldName, $label);
+            },
+            array_keys(self::COLUMNS),
+            self::COLUMNS
+        );
+    }
+
+    /**
+     * Transform array of array to array of Models
+     * @param array $collection
+     * @return array
+     */
+    protected function transformCollectionToModel(array $collection)
+    {
+        $collection = array_map(function ($data) {
+                return $this->getModel($data);
+            },
+            $collection
+        );
+
+        return $collection;
+    }
+
+    /**
+     * @param array $data
+     * @return TestModel
+     */
+    protected function getModel(array $data = [])
+    {
+        $testModel = new TestModel();
+
+        if (count($data)) {
+            foreach ($data as $key => $element) {
+                $testModel->{$key} = $element;
+            }
+        }
+
+        return $testModel;
+    }
+
+    protected function getExportModel()
+    {
+        return m::mock(ExportModel::class);
+    }
+
+    /**
+     * @param SectionModelConfiguration $model
+     * @return ExportModelHandler
+     */
+    protected function getExportModelHandler(SectionModelConfiguration $model)
+    {
+        $exportModelHandler = new ExportModelHandler();
+        $exportModelHandler->initDisplay($model);
+
+        return $exportModelHandler;
+    }
+
+    /**
+     * @covers ExportModelHandler::handle()
+     */
+    public function test_get_data()
+    {
+        $section = $this->getSection();
+
+        $data = $this->getExportModelHandler($section)->getData($section);
+
+        $this->assertCount(2, $data);
+        $this->assertEquals(array_values(self::COLUMNS), $data[1]);
+        $this->assertEquals(array_map('array_values', self::COLLECTION), array_slice($data, 1));
+    }
+}
+
+class TestTableSection extends \SleepingOwl\Admin\Section
+{
+    /** @var  \Illuminate\Support\Collection */
+    protected $collection;
+
+    /** @var  array */
+    protected $columns;
+
+    public function __construct(\Illuminate\Contracts\Foundation\Application $app)
+    {
+        parent::__construct($app, TestModel::class);
+    }
+
+    public function setColumns($columns)
+    {
+        $this->columns = $columns;
+    }
+
+    public function onDisplay()
+    {
+        $display = new TestDisplayTable();
+        $display->setCollection($this->getCollection());
+        $display->setColumns($this->columns);
+
+        return $display;
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function getCollection()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * @param array $collection
+     */
+    public function setCollection($collection)
+    {
+        $this->collection = collect($collection);
+    }
+}
+
+class TestModel extends \Illuminate\Database\Eloquent\Model
+{}
+
+class TestDisplayTable extends \SleepingOwl\Admin\Display\DisplayTable
+{
+    /** @var  array */
+    protected $collection;
+
+    /**
+     * @return array
+     */
+    public function getCollection()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * @param \Illuminate\Support\Collection $collection
+     */
+    public function setCollection($collection)
+    {
+        $this->collection = $collection;
+    }
+}

--- a/tests/Admin/Http/Request/ExportModelHandlerTest.php
+++ b/tests/Admin/Http/Request/ExportModelHandlerTest.php
@@ -66,11 +66,11 @@ class ExportModelHandlerTest extends TestCase
 
     /**
      * @param array $data
-     * @return TestModel
+     * @return TestEloquentModel
      */
     protected function getModel(array $data = [])
     {
-        $testModel = new TestModel();
+        $testModel = new TestEloquentModel();
 
         if (count($data)) {
             foreach ($data as $key => $element) {
@@ -123,7 +123,7 @@ class TestTableSection extends \SleepingOwl\Admin\Section
 
     public function __construct(\Illuminate\Contracts\Foundation\Application $app)
     {
-        parent::__construct($app, TestModel::class);
+        parent::__construct($app, TestEloquentModel::class);
     }
 
     public function setColumns($columns)
@@ -157,7 +157,7 @@ class TestTableSection extends \SleepingOwl\Admin\Section
     }
 }
 
-class TestModel extends \Illuminate\Database\Eloquent\Model
+class TestEloquentModel extends \Illuminate\Database\Eloquent\Model
 {}
 
 class TestDisplayTable extends \SleepingOwl\Admin\Display\DisplayTable

--- a/tests/Admin/Http/Request/ExportModelHandlerTest.php
+++ b/tests/Admin/Http/Request/ExportModelHandlerTest.php
@@ -8,12 +8,12 @@ use SleepingOwl\Admin\Model\SectionModelConfiguration;
 class ExportModelHandlerTest extends TestCase
 {
     const COLLECTION = [
-        ['field1' => 'test1', 'field2' => 'test2']
+        ['field1' => 'test1', 'field2' => 'test2'],
     ];
 
     const COLUMNS = [
         'field1' => 'Test1',
-        'field2' => 'Test2'
+        'field2' => 'Test2',
     ];
 
     public function tearDown()
@@ -41,23 +41,23 @@ class ExportModelHandlerTest extends TestCase
     protected function getColumns()
     {
         return array_map(function ($fieldName, $label) {
-                return \AdminColumn::text($fieldName, $label);
-            },
+            return \AdminColumn::text($fieldName, $label);
+        },
             array_keys(self::COLUMNS),
             self::COLUMNS
         );
     }
 
     /**
-     * Transform array of array to array of Models
+     * Transform array of array to array of Models.
      * @param array $collection
      * @return array
      */
     protected function transformCollectionToModel(array $collection)
     {
         $collection = array_map(function ($data) {
-                return $this->getModel($data);
-            },
+            return $this->getModel($data);
+        },
             $collection
         );
 
@@ -115,10 +115,10 @@ class ExportModelHandlerTest extends TestCase
 
 class TestTableSection extends \SleepingOwl\Admin\Section
 {
-    /** @var  \Illuminate\Support\Collection */
+    /** @var \Illuminate\Support\Collection */
     protected $collection;
 
-    /** @var  array */
+    /** @var array */
     protected $columns;
 
     public function __construct(\Illuminate\Contracts\Foundation\Application $app)
@@ -158,11 +158,12 @@ class TestTableSection extends \SleepingOwl\Admin\Section
 }
 
 class TestEloquentModel extends \Illuminate\Database\Eloquent\Model
-{}
+{
+}
 
 class TestDisplayTable extends \SleepingOwl\Admin\Display\DisplayTable
 {
-    /** @var  array */
+    /** @var array */
     protected $collection;
 
     /**


### PR DESCRIPTION
Добавлен функционал экспорта данных в табличном виде в эксель через контроллер. Данные экспортируются как и при листинге без учета пагинации и с учетом фильтров.
Экспорт реализован на основе библиотеки **maatwebsite/excel**, которая добавлена в зависимости.

Для экспорта достаточно вставить подобную ссылку при отображении табличного листинга:
```php
$display->extend('links', new LinksExtension())->setLinks([
            Link::create(
                route('admin.export',  array_merge(['model' => $this->getAlias()], request()->query())),
                'Export to csv'
            )->blank(),
        ]);
```