### PR TITLE
AdminFormElement::checkbox(...)->setReadonly(true)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
  
  #coming soon....
  
+ * [Bug-Fix] Исправлено поведение `AdminFormElement::checkbox(...)->setReadonly(true)`
+ 
 ### 4.99.99 
  * [Feature] Появился setUsage у селекто-подобных элементов (dev-mode) - не известно какие проблемы это повлечет за собой - однако несколько уже решаются.
  * [Feature] Добавлены плагины image2, youtube, uploadimage - в CKEditor. Параметры uploadUrl и filebrowserUploadUrl 

--- a/resources/views/default/form/element/checkbox.blade.php
+++ b/resources/views/default/form/element/checkbox.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group form-element-checkbox {{ $errors->has($name) ? 'has-error' : '' }}">
 	<div class="checkbox">
 		<label>
-			<input {!! $attributes !!} type="checkbox" value="1" {!! $value ? 'checked="checked"' : '' !!} />
+			<input {!! $attributes !!} @if($readonly) disabled @endif type="checkbox" value="1" {!! $value ? 'checked="checked"' : '' !!} />
 
 			{{ $label }}
 		</label>


### PR DESCRIPTION
Исправлено поведение элемента формы checkbox, теперь оно тоже может быть readonly.