### PR TITLE
Fix version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SleepingOwl Admin is an administrative interface builder for Laravel.
 
  1. Require this package in your composer.json and run composer update:
 
-  	`composer require laravelrus/sleepingowl:4.*@dev`
+  	`composer require laravelrus/sleepingowl:4.x-dev`
     
 
  2. After composer update, insert service provider in config/app.php


### PR DESCRIPTION
При установке совы согласно мануала для версии Laravel 5.6 и php 7.2 получаем ошибку:
ReflectionException  : Method SleepingOwl\Admin\Console\Commands\InstallCommand::handle() does not exist
Данная проблема озвучена ранее на форуме: https://laravel.ru/forum/viewtopic.php?id=3447
и протестирована мною лично.