### PR TITLE
Мелкие исправления.

### DIFF
--- a/src/Contracts/ModelConfigurationInterface.php
+++ b/src/Contracts/ModelConfigurationInterface.php
@@ -51,9 +51,10 @@ interface ModelConfigurationInterface
     public function getCreateTitle();
 
     /**
+     * @param Model $model
      * @return string|\Symfony\Component\Translation\TranslatorInterface
      */
-    public function getEditTitle();
+    public function getEditTitle(Model $model);
 
     /**
      * @return bool
@@ -185,44 +186,51 @@ interface ModelConfigurationInterface
     public function getCancelUrl(array $parameters = []);
 
     /**
-     * @return string
-     */
-    public function getStoreUrl();
-
-    /**
-     * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getEditUrl($id);
+    public function getStoreUrl(array $parameters = []);
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getUpdateUrl($id);
+    public function getEditUrl($id, array $parameters = []);
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getDeleteUrl($id);
+    public function getUpdateUrl($id, array $parameters = []);
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getDestroyUrl($id);
+    public function getDeleteUrl($id, array $parameters = []);
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getRestoreUrl($id);
+    public function getDestroyUrl($id, array $parameters = []);
+
+    /**
+     * @param string|int $id
+     * @param array $parameters
+     *
+     * @return string
+     */
+    public function getRestoreUrl($id, array $parameters = []);
 
     /**
      * @return string

--- a/src/Display/Display.php
+++ b/src/Display/Display.php
@@ -279,7 +279,7 @@ abstract class Display implements DisplayInterface
     /**
      * @return ModelConfigurationInterface
      */
-    protected function getModelConfiguration()
+    public function getModelConfiguration()
     {
         return app('sleeping_owl')->getModel($this->modelClass);
     }

--- a/src/Display/DisplayTree.php
+++ b/src/Display/DisplayTree.php
@@ -325,14 +325,6 @@ class DisplayTree extends Display implements WithRoutesInterface
     }
 
     /**
-     * @return ModelConfigurationInterface
-     */
-    protected function getModelConfiguration()
-    {
-        return app('sleeping_owl')->getModel($this->modelClass);
-    }
-
-    /**
      * @return Collection
      * @throws \Exception
      */

--- a/src/Form/FormDefault.php
+++ b/src/Form/FormDefault.php
@@ -301,12 +301,7 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
             return false;
         }
 
-        parent::save($request);
-
         $model = $this->getModel();
-
-        $this->saveBelongsToRelations($model);
-
         $loaded = $model->exists;
 
         if ($this->getModelConfiguration()->fireEvent($loaded ? 'updating' : 'creating', true, $model) === false) {
@@ -316,6 +311,9 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
         if ($this->getModelConfiguration()->fireEvent('saving', true, $model) === false) {
             return false;
         }
+
+        parent::save($request);
+        $this->saveBelongsToRelations($model);
 
         $model->save();
 

--- a/src/Http/Controllers/AdminController.php
+++ b/src/Http/Controllers/AdminController.php
@@ -239,13 +239,13 @@ class AdminController extends Controller
             abort(404);
         }
 
-        $this->registerBreadcrumb($model->getEditTitle(), $this->parentBreadcrumb);
+        $this->registerBreadcrumb($model->getEditTitle($item), $this->parentBreadcrumb);
 
         $edit = $model->fireEdit($id);
 
         $this->registerBreadcrumbs($model);
 
-        return $this->render($model, $edit, $model->getEditTitle());
+        return $this->render($model, $edit, $model->getEditTitle($item));
     }
 
     /**

--- a/src/Model/ModelConfiguration.php
+++ b/src/Model/ModelConfiguration.php
@@ -180,12 +180,13 @@ class ModelConfiguration extends ModelConfigurationManager
     }
 
     /**
+     * @param Model $model
      * @return string|\Symfony\Component\Translation\TranslatorInterface
      */
-    public function getEditTitle()
+    public function getEditTitle(Model $model)
     {
         if (is_null($this->editTitle)) {
-            return parent::getEditTitle();
+            return parent::getEditTitle($model);
         }
 
         return $this->editTitle;

--- a/src/Model/ModelConfigurationManager.php
+++ b/src/Model/ModelConfigurationManager.php
@@ -194,9 +194,10 @@ abstract class ModelConfigurationManager implements ModelConfigurationInterface
     }
 
     /**
-     * @return string|\Symfony\Component\Translation\TranslatorInterface
+     * @param Model $model
+     * @return array|\Illuminate\Contracts\Translation\Translator|null|string|\Symfony\Component\Translation\TranslatorInterface
      */
-    public function getEditTitle()
+    public function getEditTitle(Model $model)
     {
         return trans('sleeping_owl::lang.model.edit', ['title' => $this->getTitle()]);
     }
@@ -376,61 +377,80 @@ abstract class ModelConfigurationManager implements ModelConfigurationInterface
     }
 
     /**
+     * @param array $parameters
+     *
      * @return string
      */
-    public function getStoreUrl()
+    public function getStoreUrl(array $parameters = [])
     {
-        return route('admin.model.store', $this->getAlias());
+        array_unshift($parameters, $this->getAlias());
+
+        return route('admin.model.store', $parameters);
     }
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getEditUrl($id)
+    public function getEditUrl($id, array $parameters = [])
     {
-        return route('admin.model.edit', [$this->getAlias(), $id]);
+        array_unshift($parameters, $this->getAlias(), $id);
+
+        return route('admin.model.edit', $parameters);
     }
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getUpdateUrl($id)
+    public function getUpdateUrl($id, array $parameters = [])
     {
-        return route('admin.model.update', [$this->getAlias(), $id]);
+        array_unshift($parameters, $this->getAlias(), $id);
+
+        return route('admin.model.update', $parameters);
     }
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getDeleteUrl($id)
+    public function getDeleteUrl($id, array $parameters = [])
     {
-        return route('admin.model.delete', [$this->getAlias(), $id]);
+        array_unshift($parameters, $this->getAlias(), $id);
+
+        return route('admin.model.delete', $parameters);
     }
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getDestroyUrl($id)
+    public function getDestroyUrl($id, array $parameters = [])
     {
-        return route('admin.model.destroy', [$this->getAlias(), $id]);
+        array_unshift($parameters, $this->getAlias(), $id);
+
+        return route('admin.model.destroy', $parameters);
     }
 
     /**
      * @param string|int $id
+     * @param array $parameters
      *
      * @return string
      */
-    public function getRestoreUrl($id)
+    public function getRestoreUrl($id, array $parameters = [])
     {
-        return route('admin.model.restore', [$this->getAlias(), $id]);
+        array_unshift($parameters, $this->getAlias(), $id);
+
+        return route('admin.model.restore', $parameters);
     }
 
     /**
@@ -589,7 +609,7 @@ abstract class ModelConfigurationManager implements ModelConfigurationInterface
     public function __call($method, $arguments)
     {
         if (in_array($method, [
-            'creating', 'created', 'updating', 'updated',
+            'creating', 'created', 'updating', 'updated', 'saving', 'saved',
             'deleting', 'deleted', 'restoring', 'restored',
         ])) {
             array_unshift($arguments, $method);

--- a/tests/Admin/Model/ModelConfigurationManagerTest.php
+++ b/tests/Admin/Model/ModelConfigurationManagerTest.php
@@ -92,7 +92,7 @@ class ModelConfigurationManagerTest extends TestCase
             ->with('sleeping_owl::lang.model.edit', ['title' => $model->getTitle()], null)
             ->andReturn('string');
 
-        $this->assertEquals('string', $model->getEditTitle());
+        $this->assertEquals('string', $model->getEditTitle($model->getModel()));
     }
 
     /**
@@ -297,11 +297,11 @@ class ModelConfigurationManagerTest extends TestCase
 
         $this->getRouterMock()->shouldReceive('route')->once()->withArgs([
             'admin.model.store',
-            $model->getAlias(),
+            [$model->getAlias(), 'locale' => 'en'],
             true,
         ])->andReturn('http://site.com');
 
-        $this->assertEquals('http://site.com', $model->getStoreUrl());
+        $this->assertEquals('http://site.com', $model->getStoreUrl(['locale' => 'en']));
     }
 
     /**
@@ -313,11 +313,11 @@ class ModelConfigurationManagerTest extends TestCase
 
         $this->getRouterMock()->shouldReceive('route')->once()->withArgs([
             'admin.model.edit',
-            [$model->getAlias(), 1],
+            [$model->getAlias(), 1, 'locale' => 'en'],
             true,
         ])->andReturn('http://site.com');
 
-        $this->assertEquals('http://site.com', $model->getEditUrl(1));
+        $this->assertEquals('http://site.com', $model->getEditUrl(1, ['locale' => 'en']));
     }
 
     /**
@@ -329,11 +329,11 @@ class ModelConfigurationManagerTest extends TestCase
 
         $this->getRouterMock()->shouldReceive('route')->once()->withArgs([
             'admin.model.update',
-            [$model->getAlias(), 1],
+            [$model->getAlias(), 1, 'locale' => 'en'],
             true,
         ])->andReturn('http://site.com');
 
-        $this->assertEquals('http://site.com', $model->getUpdateUrl(1));
+        $this->assertEquals('http://site.com', $model->getUpdateUrl(1, ['locale' => 'en']));
     }
 
     /**
@@ -345,11 +345,11 @@ class ModelConfigurationManagerTest extends TestCase
 
         $this->getRouterMock()->shouldReceive('route')->once()->withArgs([
             'admin.model.delete',
-            [$model->getAlias(), 1],
+            [$model->getAlias(), 1, 'locale' => 'en'],
             true,
         ])->andReturn('http://site.com');
 
-        $this->assertEquals('http://site.com', $model->getDeleteUrl(1));
+        $this->assertEquals('http://site.com', $model->getDeleteUrl(1, ['locale' => 'en']));
     }
 
     /**
@@ -361,11 +361,11 @@ class ModelConfigurationManagerTest extends TestCase
 
         $this->getRouterMock()->shouldReceive('route')->once()->withArgs([
             'admin.model.destroy',
-            [$model->getAlias(), 1],
+            [$model->getAlias(), 1, 'locale' => 'en'],
             true,
         ])->andReturn('http://site.com');
 
-        $this->assertEquals('http://site.com', $model->getDestroyUrl(1));
+        $this->assertEquals('http://site.com', $model->getDestroyUrl(1, ['locale' => 'en']));
     }
 
     /**
@@ -377,11 +377,11 @@ class ModelConfigurationManagerTest extends TestCase
 
         $this->getRouterMock()->shouldReceive('route')->once()->withArgs([
             'admin.model.restore',
-            [$model->getAlias(), 1],
+            [$model->getAlias(), 1, 'locale' => 'en'],
             true,
         ])->andReturn('http://site.com');
 
-        $this->assertEquals('http://site.com', $model->getRestoreUrl(1));
+        $this->assertEquals('http://site.com', $model->getRestoreUrl(1, ['locale' => 'en']));
     }
 
     /**

--- a/tests/Admin/Model/ModelConfigurationTest.php
+++ b/tests/Admin/Model/ModelConfigurationTest.php
@@ -78,10 +78,10 @@ class ModelConfigurationTest extends TestCase
             ->once()
             ->with('sleeping_owl::lang.model.edit', ['title' => $model->getTitle()], null)
             ->andReturn('string');
-        $this->assertEquals('string', $model->getEditTitle());
+        $this->assertEquals('string', $model->getEditTitle($model->getModel()));
 
         $this->assertEquals($model, $model->setEditTitle('test'));
-        $this->assertEquals('test', $model->getEditTitle());
+        $this->assertEquals('test', $model->getEditTitle($model->getModel()));
     }
 
     /**


### PR DESCRIPTION
- Добавлены пропущенные события `saving`, `saved`
- Убран лишний метод получения объекта [ModelConfiguration](https://github.com/LaravelRUS/SleepingOwlAdmin/blob/development/src/Display/DisplayTree.php#L331)
- Передача объекта записи в метод получения заголовка для страницы редактирования документа. Это позволит в форме редактирования записи использовать заголовок из модели.
- Добавлена возможность передавать в методы создания URL дополнительные параметры. В моей задаче необходимо было добавить в необходимые url, текущий язык записи.
- Изменен (исправлен) порядок вызова событий до сохранения данных в модели. (Желательно этот пункт проверить, т.к. вдруг где-то на этом порядке что либо завязано)