### PR TITLE
setCollection($collection) in DisplayTable

### DIFF
--- a/src/Display/DisplayTable.php
+++ b/src/Display/DisplayTable.php
@@ -189,6 +189,14 @@ class DisplayTable extends Display
 
         return $params;
     }
+    
+    /**
+     * $collection Collection|LengthAwarePaginator|Builder
+     */
+    public function setCollection($collection)
+    {
+        $this->collection = $collection;
+    }
 
     /**
      * @return Collection|LengthAwarePaginator|Builder

--- a/src/Display/DisplayTable.php
+++ b/src/Display/DisplayTable.php
@@ -189,9 +189,9 @@ class DisplayTable extends Display
 
         return $params;
     }
-    
+
     /**
-     * $collection Collection|LengthAwarePaginator|Builder
+     * $collection Collection|LengthAwarePaginator|Builder.
      */
     public function setCollection($collection)
     {


### PR DESCRIPTION
При использовании `$this->setControllerClass(class);` в секции, теперь можно в контроллере передавать коллекцию в `onDisplay`.
Для этого в методе 
`getDisplay(ModelConfigurationInterface $model)` 
после 
`$display = $model->fireDisplay(); `
вызываем
`$display->setCollection($my_collection);`