### PR TITLE
Update Custom column parent class

### DIFF
--- a/src/Display/Column/Custom.php
+++ b/src/Display/Column/Custom.php
@@ -3,9 +3,8 @@
 namespace SleepingOwl\Admin\Display\Column;
 
 use Closure;
-use SleepingOwl\Admin\Display\TableColumn;
 
-class Custom extends TableColumn
+class Custom extends NamedColumn
 {
     /**
      * Callback to render column contents.


### PR DESCRIPTION
Change custom column. change parent class to Named Column. Column filter now works. Just name of column should be set.
setName('column_name') 