### PR TITLE
Add ability to order DataTables column with nested relations

### DIFF
--- a/src/Display/Column/OrderByClause.php
+++ b/src/Display/Column/OrderByClause.php
@@ -112,28 +112,22 @@ class OrderByClause implements OrderByClauseInterface
         $relations = collect(explode('.', $this->name));
         $loop = 0;
         if ($relations->count() >= 2) {
-
             $query->select($query->getModel()->getTable().'.*');
 
             do {
-
                 $model = ! $loop++ ? $query->getModel() : $relationClass->getModel();
                 $relation = $relations->shift();
 
                 if (method_exists($model, $relation)) {
-
                     $relationClass = $model->{$relation}();
                     $relationModel = $relationClass->getRelated();
 
                     $loadRelationMethod = implode('', ['load', class_basename(get_class($relationClass))]);
                     call_user_func([$this, $loadRelationMethod],
                         $relations, $relationClass, $relationModel, $model, $query, $direction);
-
                 } else {
-
                     break;
                 }
-
             } while (true);
 
             if ($this->sortedColumnAlias) {

--- a/src/Display/Column/OrderByClause.php
+++ b/src/Display/Column/OrderByClause.php
@@ -26,11 +26,6 @@ class OrderByClause implements OrderByClauseInterface
     protected $sortedColumnAlias = null;
 
     /**
-     * @var string|null
-     */
-    protected $direction = null;
-
-    /**
      * OrderByClause constructor.
      *
      * @param string|Closure $name
@@ -202,7 +197,6 @@ class OrderByClause implements OrderByClauseInterface
         $sortedColumnAlias = implode('__', [$foreignTable, $relations->last()]);
 
         $this->sortedColumnAlias = $sortedColumnAlias;
-        $this->direction = $direction;
 
         $query
             ->addSelect([DB::raw($sortedColumnRaw.' AS '.$sortedColumnAlias)])
@@ -238,7 +232,6 @@ class OrderByClause implements OrderByClauseInterface
         $sortedColumnAlias = implode('__', [$foreignTable, $relations->last()]);
 
         $this->sortedColumnAlias = $sortedColumnAlias;
-        $this->direction = $direction;
 
         $query
             ->addSelect([DB::raw($sortedColumnRaw.' AS '.$sortedColumnAlias)])

--- a/src/Display/Column/OrderByClause.php
+++ b/src/Display/Column/OrderByClause.php
@@ -117,7 +117,7 @@ class OrderByClause implements OrderByClauseInterface
 
             do {
 
-                $model = !$loop++ ? $query->getModel() : $relationClass->getModel();
+                $model = ! $loop++ ? $query->getModel() : $relationClass->getModel();
                 $relation = $relations->shift();
 
                 if (method_exists($model, $relation)) {
@@ -136,8 +136,9 @@ class OrderByClause implements OrderByClauseInterface
 
             } while (true);
 
-            if ($this->sortedColumnAlias)
+            if ($this->sortedColumnAlias) {
                 $query->orderBy(DB::raw($this->sortedColumnAlias), $direction);
+            }
         }
     }
 
@@ -211,8 +212,7 @@ class OrderByClause implements OrderByClauseInterface
 
         $query
             ->addSelect([DB::raw($sortedColumnRaw.' AS '.$sortedColumnAlias)])
-            ->join($foreignTable, $foreignColumn, '=', $ownerColumn, 'left')
-        ;
+            ->join($foreignTable, $foreignColumn, '=', $ownerColumn, 'left');
     }
 
     /**
@@ -248,7 +248,6 @@ class OrderByClause implements OrderByClauseInterface
 
         $query
             ->addSelect([DB::raw($sortedColumnRaw.' AS '.$sortedColumnAlias)])
-            ->join($foreignTable, $foreignColumn, '=', $ownerColumn, 'left')
-        ;
+            ->join($foreignTable, $foreignColumn, '=', $ownerColumn, 'left');
     }
 }


### PR DESCRIPTION
Now it work correctly:
`AdminColumn::text('material.title')->setLabel('Название'),`

But it is not:
`AdminColumn::text('material.brand.title')->setLabel('Бренд')`

Let's solve this problem! Load all nested relations in loop via left-join & order by last order field.
👍 