### PR TITLE
Fix password field completion

### DIFF
--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -2,17 +2,17 @@
 
 namespace SleepingOwl\Admin\Form\Element;
 
-use Illuminate\Contracts\Support\Htmlable;
+use LogicException;
+use Illuminate\Support\Arr;
+use SleepingOwl\Admin\Form\FormElement;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Contracts\Support\Htmlable;
+use KodiComponents\Support\HtmlAttributes;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Arr;
-use KodiComponents\Support\HtmlAttributes;
-use LogicException;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use SleepingOwl\Admin\Exceptions\Form\FormElementException;
-use SleepingOwl\Admin\Form\FormElement;
 
 abstract class NamedFormElement extends FormElement
 {

--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -4,8 +4,8 @@ namespace SleepingOwl\Admin\Form\Element;
 
 use LogicException;
 use Illuminate\Support\Arr;
-use SleepingOwl\Admin\Form\FormElement;
 use Illuminate\Database\Eloquent\Model;
+use SleepingOwl\Admin\Form\FormElement;
 use Illuminate\Contracts\Support\Htmlable;
 use KodiComponents\Support\HtmlAttributes;
 use Illuminate\Database\Eloquent\Relations\HasOne;

--- a/src/Form/Element/Password.php
+++ b/src/Form/Element/Password.php
@@ -10,7 +10,7 @@ class Password extends NamedFormElement
 
         $this->setHtmlAttributes([
             'class' => 'form-control',
-            'type' => 'password',
+            'type'  => 'password',
         ]);
     }
 
@@ -38,6 +38,28 @@ class Password extends NamedFormElement
         }
 
         parent::save($request);
+    }
+
+    /**
+     * Checks if value exists only inside request instance. Otherwise it'll return null, because password hash
+     * should not be returned from model and rendered inside forms.
+     *
+     * @return array|mixed|null|string
+     */
+    public function getValueFromModel()
+    {
+        if (($value = $this->getValueFromRequest(request())) !== null) {
+            return $value;
+        }
+
+        $model = $this->getModel();
+
+        if ($model === null || ! $model->exists) {
+            // Returning default value only if model is not stored and value was not hashed
+            return $this->getDefaultValue();
+        }
+
+        return null;
     }
 
     /**

--- a/src/Form/Element/Password.php
+++ b/src/Form/Element/Password.php
@@ -52,14 +52,7 @@ class Password extends NamedFormElement
             return $value;
         }
 
-        $model = $this->getModel();
-
-        if ($model === null || ! $model->exists) {
-            // Returning default value only if model is not stored and value was not hashed
-            return $this->getDefaultValue();
-        }
-
-        return null;
+        return $this->getDefaultValue();
     }
 
     /**

--- a/tests/Admin/Form/Element/NamedFormElementTest.php
+++ b/tests/Admin/Form/Element/NamedFormElementTest.php
@@ -13,6 +13,7 @@ class NamedFormElementTest extends TestCase
     /**
      * @param string $path
      * @param null $label
+     *
      * @return \PHPUnit\Framework\MockObject\MockObject
      * @throws ReflectionException
      */
@@ -157,7 +158,10 @@ class NamedFormElementTest extends TestCase
 
         $element->addValidationMessage('test', 'test message');
         $element->addValidationMessage('hello', 'hello message');
-        $this->assertEquals(['key.test' => 'test message', 'key.hello' => 'hello message'], $element->getValidationMessages());
+        $this->assertEquals([
+            'key.test'  => 'test message',
+            'key.hello' => 'hello message',
+        ], $element->getValidationMessages());
     }
 
     /**
@@ -258,7 +262,8 @@ class NamedFormElementTest extends TestCase
         $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->exists = true;
 
-        $model->shouldReceive('getAttribute')->andReturn($subModel = m::mock(\Illuminate\Database\Eloquent\Model::class));
+        $model->shouldReceive('getAttribute')
+            ->andReturn($subModel = m::mock(\Illuminate\Database\Eloquent\Model::class));
 
         $this->assertEquals($subModel, $element->resolvePath());
 
@@ -296,15 +301,15 @@ class NamedFormElementTest extends TestCase
         $session->shouldReceive('getOldInput')->andReturn(null);
 
         $this->assertEquals([
-            'value' => null,
-            'readonly' => false,
-            'model' => null,
-            'id' => 'key2[subkey]',
-            'name' => 'key2[subkey]',
-            'path' => 'key2.subkey',
-            'label' => 'Label',
-            'helpText' => null,
-            'required' => false,
+            'value'      => null,
+            'readonly'   => false,
+            'model'      => null,
+            'id'         => 'key2[subkey]',
+            'name'       => 'key2[subkey]',
+            'path'       => 'key2.subkey',
+            'label'      => 'Label',
+            'helpText'   => null,
+            'required'   => false,
             'attributes' => ' id="key2[subkey]" name="key2[subkey]"',
         ], $element->toArray());
     }
@@ -347,7 +352,7 @@ class NamedFormElementTest extends TestCase
 
         $model = new NamedFormElementTestModuleForTestingSkippedValues();
         foreach ([$nameElement, $passwordElement] as $element) {
-            /* @var $element NamedFormElement  */
+            /* @var $element NamedFormElement */
             $element->setModel($model);
             $element->setModelAttribute($element->getLabel());
         }
@@ -396,9 +401,9 @@ class NamedFormElementTest extends TestCase
         $this->assertNull($this->callMethodByPath($element, 'key.key1'));
 
         $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
-        $model->shouldReceive('getAttribute')->with('key')->andReturn(
-            $model1 = m::mock(\Illuminate\Database\Eloquent\Model::class)
-        );
+        $model->shouldReceive('getAttribute')
+            ->with('key')
+            ->andReturn($model1 = m::mock(\Illuminate\Database\Eloquent\Model::class));
 
         $this->assertEquals($model1, $this->callMethodByPath($element, 'key.key1'));
     }
@@ -411,9 +416,9 @@ class NamedFormElementTest extends TestCase
         $element = $this->getElement('key', 'Label');
 
         $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
-        $model->shouldReceive('getAttribute')->with('key')->andReturn(
-            $model1 = m::mock(\Illuminate\Database\Eloquent\Model::class)
-        );
+        $model->shouldReceive('getAttribute')
+            ->with('key')
+            ->andReturn($model1 = m::mock(\Illuminate\Database\Eloquent\Model::class));
 
         $model1->shouldReceive('getAttribute')->with('key1');
 
@@ -423,6 +428,7 @@ class NamedFormElementTest extends TestCase
     /**
      * @param NamedFormElement $element
      * @param $path
+     *
      * @return mixed
      * @throws ReflectionException
      */

--- a/tests/Admin/Form/Element/PasswordTest.php
+++ b/tests/Admin/Form/Element/PasswordTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SleepingOwl\Tests\Admin\Form\Element;
+
+use Mockery as m;
+
+class PasswordTest extends \TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    /**
+     * @covers \SleepingOwl\Admin\Form\Element\Password::getValueFromModel()
+     * @throws \SleepingOwl\Admin\Exceptions\Form\FormElementException
+     */
+    public function test_gets_value_from_request()
+    {
+        $request = $this->app['request'];
+        $element = new \SleepingOwl\Admin\Form\Element\Password('password', 'Password');
+
+        $session = $request->getSession();
+        $session->shouldReceive('getOldInput')->andReturn(null);
+
+        $request->offsetSet('password', 'secret');
+
+        $this->assertEquals('secret', $element->getValueFromModel());
+
+        $request->offsetSet('password', null);
+
+        $model = new TestModelForPasswordElement(['password' => 'hashed_password']);
+        $element->setModel($model);
+        $this->assertEquals(null, $element->getValueFromModel());
+    }
+}
+
+class TestModelForPasswordElement extends \Illuminate\Database\Eloquent\Model
+{
+    protected $fillable = ['password'];
+}

--- a/tests/Admin/Form/Element/PasswordTest.php
+++ b/tests/Admin/Form/Element/PasswordTest.php
@@ -38,5 +38,4 @@ class PasswordTest extends \TestCase
 class TestModelForPasswordElement extends \Illuminate\Database\Eloquent\Model
 {
     protected $fillable = ['password'];
-
 }

--- a/tests/Admin/Form/Element/PasswordTest.php
+++ b/tests/Admin/Form/Element/PasswordTest.php
@@ -38,4 +38,5 @@ class PasswordTest extends \TestCase
 class TestModelForPasswordElement extends \Illuminate\Database\Eloquent\Model
 {
     protected $fillable = ['password'];
+
 }


### PR DESCRIPTION
When password field renders value it should be returned only from request, because value from model contains hash of password and should not be rendered at all.