### PR TITLE
fixes for MultiDependentSelect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ env:
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 allow_failures:
   - php: nightly

--- a/resources/views/default/form/element/multiselect.blade.php
+++ b/resources/views/default/form/element/multiselect.blade.php
@@ -29,7 +29,7 @@
                          placeholder="{{ trans('sleeping_owl::lang.select.no_items') }}"
                          @endif
                          @tag="addTag"
-                         :taggable="{{ $tagable ? 'true' : 'false'}}"
+                         :taggable="{{ $taggable ? 'true' : 'false'}}"
                          :select-label="'{{trans('sleeping_owl::lang.select.init')}}'"
                          :selected-label="'{{trans('sleeping_owl::lang.select.selected')}}'"
                          :deselect-label="'{{trans('sleeping_owl::lang.select.deselect')}}'"

--- a/src/Contracts/Form/Element/HasSyncCallback.php
+++ b/src/Contracts/Form/Element/HasSyncCallback.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SleepingOwl\Admin\Contracts\Form\Element;
+
+interface HasSyncCallback
+{
+    /**
+     * @return \Closure
+     */
+    public function getSyncCallback();
+
+    /**
+     * @param \Closure $callable
+     * @return $this
+     */
+    public function setSyncCallback(\Closure $callable);
+}

--- a/src/Contracts/Form/Element/MustDeleteRelatedItem.php
+++ b/src/Contracts/Form/Element/MustDeleteRelatedItem.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SleepingOwl\Admin\Contracts\Form\Element;
+
+interface MustDeleteRelatedItem
+{
+    /**
+     * @return bool
+     */
+    public function isDeleteRelatedItem();
+
+    /**
+     * @return $this
+     */
+    public function deleteRelatedItem();
+}

--- a/src/Contracts/Form/Element/Taggable.php
+++ b/src/Contracts/Form/Element/Taggable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SleepingOwl\Admin\Contracts\Form\Element;
+
+interface Taggable
+{
+    /**
+     * @return bool
+     */
+    public function isTaggable();
+
+    /**
+     * @return $this
+     */
+    public function taggable();
+}

--- a/src/Factories/FormElementFactory.php
+++ b/src/Factories/FormElementFactory.php
@@ -79,7 +79,7 @@ class FormElementFactory extends AliasBinder implements FormElementFactoryInterf
             'html' => Element\Html::class,
             'number' => Element\Number::class,
             'dependentselect' => Element\DependentSelect::class,
-            'multidependselect' => Element\MultiDependentSelect::class,
+            'multidependentselect' => Element\MultiDependentSelect::class,
             'selectajax' => Element\SelectAjax::class,
             'multiselectajax' => Element\MultiSelectAjax::class,
             'hasMany' => Forms\HasMany::class,

--- a/src/Form/Element/MultiDependentSelect.php
+++ b/src/Form/Element/MultiDependentSelect.php
@@ -2,13 +2,11 @@
 
 namespace SleepingOwl\Admin\Form\Element;
 
-use SleepingOwl\Admin\Contracts\Form\Element\MustDeleteRelatedItem;
-use SleepingOwl\Admin\Contracts\Form\Element\HasSyncCallback;
-use SleepingOwl\Admin\Contracts\Form\Element\Taggable;
-use SleepingOwl\Admin\Traits\ElementDeleteRelatedItem;
 use SleepingOwl\Admin\Traits\ElementSaveRelation;
 use SleepingOwl\Admin\Traits\ElementSyncCallback;
-use SleepingOwl\Admin\Traits\ElementTaggable;
+use SleepingOwl\Admin\Traits\ElementDeleteRelatedItem;
+use SleepingOwl\Admin\Contracts\Form\Element\HasSyncCallback;
+use SleepingOwl\Admin\Contracts\Form\Element\MustDeleteRelatedItem;
 
 class MultiDependentSelect extends DependentSelect implements HasSyncCallback, MustDeleteRelatedItem
 {

--- a/src/Form/Element/MultiDependentSelect.php
+++ b/src/Form/Element/MultiDependentSelect.php
@@ -2,11 +2,20 @@
 
 namespace SleepingOwl\Admin\Form\Element;
 
-use SleepingOwl\Admin\Traits\ElementSaveRelationTrait;
+use SleepingOwl\Admin\Contracts\Form\Element\MustDeleteRelatedItem;
+use SleepingOwl\Admin\Contracts\Form\Element\HasSyncCallback;
+use SleepingOwl\Admin\Contracts\Form\Element\Taggable;
+use SleepingOwl\Admin\Traits\ElementDeleteRelatedItem;
+use SleepingOwl\Admin\Traits\ElementSaveRelation;
+use SleepingOwl\Admin\Traits\ElementSyncCallback;
+use SleepingOwl\Admin\Traits\ElementTaggable;
 
-class MultiDependentSelect extends DependentSelect
+class MultiDependentSelect extends DependentSelect implements Taggable, HasSyncCallback, MustDeleteRelatedItem
 {
-    use ElementSaveRelationTrait;
+    use ElementSaveRelation,
+        ElementTaggable,
+        ElementSyncCallback,
+        ElementDeleteRelatedItem;
 
     /**
      * @return string
@@ -17,47 +26,21 @@ class MultiDependentSelect extends DependentSelect
     }
 
     /**
-     * @return string
-     */
-    public function getDataUrl()
-    {
-        return $this->dataUrl ?: route('admin.form.element.dependent-select', [
-            'adminModel' => \AdminSection::getModel($this->model)->getAlias(),
-            'field' => parent::getName(),
-            'id' => $this->model->getKey(),
-        ]);
-    }
-
-    /**
      * @return array
      */
     public function toArray()
     {
         $this->setHtmlAttributes([
-            'id' => $this->getName(),
-            'size' => 2,
-            'data-select-type' => 'single',
-            'data-url' => $this->getDataUrl(),
-            'data-depends' => $this->getDataDepends(),
-            'class' => 'form-control input-select input-select-dependent',
-            'multiple'=>'multiple',
+            'multiple',
         ]);
 
-        if ($this->isReadonly()) {
-            $this->setHtmlAttribute('disabled', 'disabled');
+        if ($this->isTaggable()) {
+            $this->setHtmlAttribute('class', 'input-taggable');
         }
 
         return [
-            'id' => $this->getName(),
-            'name' => $this->getName(),
-            'path' => $this->getPath(),
-            'label' => $this->getLabel(),
-            'readonly' => $this->isReadonly(),
-            'options' => $this->getOptions(),
-            'value' => $this->getValueFromModel(),
-            'helpText' => $this->getHelpText(),
-            'required' => in_array('required', $this->validationRules),
-            'attributes' => $this->getHtmlAttributes(),
-        ];
+                'taggable'    => $this->isTaggable(),
+                'attributes' => $this->htmlAttributesToString(),
+            ] + parent::toArray();
     }
 }

--- a/src/Form/Element/MultiDependentSelect.php
+++ b/src/Form/Element/MultiDependentSelect.php
@@ -10,10 +10,9 @@ use SleepingOwl\Admin\Traits\ElementSaveRelation;
 use SleepingOwl\Admin\Traits\ElementSyncCallback;
 use SleepingOwl\Admin\Traits\ElementTaggable;
 
-class MultiDependentSelect extends DependentSelect implements Taggable, HasSyncCallback, MustDeleteRelatedItem
+class MultiDependentSelect extends DependentSelect implements HasSyncCallback, MustDeleteRelatedItem
 {
     use ElementSaveRelation,
-        ElementTaggable,
         ElementSyncCallback,
         ElementDeleteRelatedItem;
 
@@ -34,13 +33,6 @@ class MultiDependentSelect extends DependentSelect implements Taggable, HasSyncC
             'multiple',
         ]);
 
-        if ($this->isTaggable()) {
-            $this->setHtmlAttribute('class', 'input-taggable');
-        }
-
-        return [
-                'taggable'    => $this->isTaggable(),
-                'attributes' => $this->htmlAttributesToString(),
-            ] + parent::toArray();
+        return parent::toArray();
     }
 }

--- a/src/Form/Element/MultiSelect.php
+++ b/src/Form/Element/MultiSelect.php
@@ -2,26 +2,20 @@
 
 namespace SleepingOwl\Admin\Form\Element;
 
-use Illuminate\Database\Eloquent\Collection;
-use SleepingOwl\Admin\Traits\ElementSaveRelationTrait;
+use SleepingOwl\Admin\Contracts\Form\Element\MustDeleteRelatedItem;
+use SleepingOwl\Admin\Contracts\Form\Element\HasSyncCallback;
+use SleepingOwl\Admin\Contracts\Form\Element\Taggable;
+use SleepingOwl\Admin\Traits\ElementDeleteRelatedItem;
+use SleepingOwl\Admin\Traits\ElementSaveRelation;
+use SleepingOwl\Admin\Traits\ElementSyncCallback;
+use SleepingOwl\Admin\Traits\ElementTaggable;
 
-class MultiSelect extends Select
+class MultiSelect extends Select implements Taggable, HasSyncCallback, MustDeleteRelatedItem
 {
-    use ElementSaveRelationTrait;
-    /**
-     * @var bool
-     */
-    protected $taggable = false;
-
-    /**
-     * @var \Closure
-     */
-    protected $syncCallback;
-
-    /**
-     * @var bool
-     */
-    protected $deleteRelatedItem = false;
+    use ElementSaveRelation,
+        ElementTaggable,
+        ElementSyncCallback,
+        ElementDeleteRelatedItem;
 
     /**
      * @var string
@@ -34,66 +28,6 @@ class MultiSelect extends Select
     public function getName()
     {
         return parent::getName().'[]';
-    }
-
-    /**
-     * @return array|string
-     */
-    public function getValueFromModel()
-    {
-        $value = parent::getValueFromModel();
-
-        if (is_array($value)) {
-            foreach ($value as $key => $val) {
-                $value[$key] = $val;
-            }
-        }
-
-        if ($value instanceof Collection && $value->count() > 0) {
-            $value = $value->pluck($value->first()->getKeyName())->all();
-        }
-
-        if ($value instanceof Collection) {
-            $value = $value->toArray();
-        }
-
-        return $value;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isTaggable()
-    {
-        return $this->taggable;
-    }
-
-    /**
-     * @return $this
-     */
-    public function taggable()
-    {
-        $this->taggable = true;
-
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isDeleteRelatedItem()
-    {
-        return $this->deleteRelatedItem;
-    }
-
-    /**
-     * @return $this
-     */
-    public function deleteRelatedItem()
-    {
-        $this->deleteRelatedItem = true;
-
-        return $this;
     }
 
     /**
@@ -116,7 +50,7 @@ class MultiSelect extends Select
         }
 
         return [
-                'tagable'    => $this->isTaggable(),
+                'taggable'    => $this->isTaggable(),
                 'attributes' => $this->htmlAttributesToString(),
             ] + parent::toArray();
     }

--- a/src/Form/Element/MultiSelect.php
+++ b/src/Form/Element/MultiSelect.php
@@ -2,13 +2,13 @@
 
 namespace SleepingOwl\Admin\Form\Element;
 
-use SleepingOwl\Admin\Contracts\Form\Element\MustDeleteRelatedItem;
-use SleepingOwl\Admin\Contracts\Form\Element\HasSyncCallback;
-use SleepingOwl\Admin\Contracts\Form\Element\Taggable;
-use SleepingOwl\Admin\Traits\ElementDeleteRelatedItem;
+use SleepingOwl\Admin\Traits\ElementTaggable;
 use SleepingOwl\Admin\Traits\ElementSaveRelation;
 use SleepingOwl\Admin\Traits\ElementSyncCallback;
-use SleepingOwl\Admin\Traits\ElementTaggable;
+use SleepingOwl\Admin\Contracts\Form\Element\Taggable;
+use SleepingOwl\Admin\Traits\ElementDeleteRelatedItem;
+use SleepingOwl\Admin\Contracts\Form\Element\HasSyncCallback;
+use SleepingOwl\Admin\Contracts\Form\Element\MustDeleteRelatedItem;
 
 class MultiSelect extends Select implements Taggable, HasSyncCallback, MustDeleteRelatedItem
 {

--- a/src/Http/Controllers/FormElementController.php
+++ b/src/Http/Controllers/FormElementController.php
@@ -7,8 +7,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Illuminate\Database\Eloquent\Model;
 use SleepingOwl\Admin\Form\Element\DependentSelect;
-use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 use SleepingOwl\Admin\Form\Element\MultiDependentSelect;
+use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 
 class FormElementController extends Controller
 {

--- a/src/Http/Controllers/FormElementController.php
+++ b/src/Http/Controllers/FormElementController.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Database\Eloquent\Model;
 use SleepingOwl\Admin\Form\Element\DependentSelect;
 use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
+use SleepingOwl\Admin\Form\Element\MultiDependentSelect;
 
 class FormElementController extends Controller
 {
@@ -54,8 +55,11 @@ class FormElementController extends Controller
             return $form;
         }
 
-        /** @var DependentSelect $element */
-        $element = $form->getElement($field);
+        // because field name in MultiDependentSelect ends with '[]'
+        $fieldPrepared = str_replace('[]', '', $field);
+
+        /** @var DependentSelect|MultiDependentSelect $element */
+        $element = $form->getElement($fieldPrepared);
 
         if (is_null($element)) {
             return new JsonResponse([
@@ -110,8 +114,11 @@ class FormElementController extends Controller
             return $form;
         }
 
-        /** @var DependentSelect $element */
-        $element = $form->getElement($field);
+        // because field name in MultiDependentSelect ends with '[]'
+        $fieldPrepared = str_replace('[]', '', $field);
+
+        /** @var DependentSelect|MultiDependentSelect $element */
+        $element = $form->getElement($fieldPrepared);
 
         if (is_null($element)) {
             return new JsonResponse([

--- a/src/Traits/ElementDeleteRelatedItem.php
+++ b/src/Traits/ElementDeleteRelatedItem.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SleepingOwl\Admin\Traits;
+
+trait ElementDeleteRelatedItem
+{
+    /**
+     * @var bool
+     */
+    protected $deleteRelatedItem = false;
+
+    /**
+     * @return bool
+     */
+    public function isDeleteRelatedItem()
+    {
+        return $this->deleteRelatedItem;
+    }
+
+    /**
+     * @return $this
+     */
+    public function deleteRelatedItem()
+    {
+        $this->deleteRelatedItem = true;
+
+        return $this;
+    }
+}

--- a/src/Traits/ElementSaveRelation.php
+++ b/src/Traits/ElementSaveRelation.php
@@ -2,11 +2,11 @@
 
 namespace SleepingOwl\Admin\Traits;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
+use SleepingOwl\Admin\Contracts\Form\Element\Taggable;
 use SleepingOwl\Admin\Contracts\Form\Element\HasSyncCallback;
 use SleepingOwl\Admin\Contracts\Form\Element\MustDeleteRelatedItem;
-use SleepingOwl\Admin\Contracts\Form\Element\Taggable;
 
 trait ElementSaveRelation
 {
@@ -88,7 +88,7 @@ trait ElementSaveRelation
         \Illuminate\Database\Eloquent\Relations\BelongsToMany $relation,
         array $values
     ) {
-        if($this instanceof Taggable) {
+        if ($this instanceof Taggable) {
             foreach ($values as $i => $value) {
                 if (! array_key_exists($value, $this->getOptions()) && $this->isTaggable()) {
                     $model = clone $this->getModelForOptions();

--- a/src/Traits/ElementSyncCallback.php
+++ b/src/Traits/ElementSyncCallback.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SleepingOwl\Admin\Traits;
+
+trait ElementSyncCallback
+{
+    /**
+     * @var \Closure
+     */
+    protected $syncCallback;
+
+    /**
+     * @return \Closure
+     */
+    public function getSyncCallback()
+    {
+        return $this->syncCallback;
+    }
+
+    /**
+     * @param \Closure $callable
+     * @return $this
+     */
+    public function setSyncCallback(\Closure $callable)
+    {
+        $this->syncCallback = $callable;
+
+        return $this;
+    }
+}

--- a/src/Traits/ElementTaggable.php
+++ b/src/Traits/ElementTaggable.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SleepingOwl\Admin\Traits;
+
+trait ElementTaggable
+{
+    /**
+     * @var bool
+     */
+    protected $taggable = false;
+
+    /**
+     * @return bool
+     */
+    public function isTaggable()
+    {
+        return $this->taggable;
+    }
+
+    /**
+     * @return $this
+     */
+    public function taggable()
+    {
+        $this->taggable = true;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Исправлены ошибки для нового MultiDependentSelect #1003:
**1)** Ошибка 404 при получении зависимого поля через ajax
**2)** Ошибка в названии `multidependselect` исправлено на `multidependentselect`
**3)** Возможности тегирование, коллбек для sync и удаление зависимых сущностей реализованы через traits и interface:

- `\Traits\ElementTaggable` -> `\Contracts\Form\Element\Taggable`
- `\Traits\ElementSyncCallback` -> `\Contracts\Form\Element\HasSyncCallback`
- `\Traits\ElementDeleteRelatedItem` -> `\Contracts\Form\Element\MustDeleteRelatedItem`

**4)** Произведен рефакторинг и удаление дублирующегося кода