### PR TITLE
адаптирование и замена классов textaddon под BS4, подключение к texta…

### DIFF
--- a/resources/views/default/form/element/textaddon.blade.php
+++ b/resources/views/default/form/element/textaddon.blade.php
@@ -1,23 +1,27 @@
 @if ($displayed)
-	<div class="form-group form-element-textaddon {{ $errors->has($name) ? 'has-error' : '' }}">
-		<label for="{{ $name }}" class="control-label {{ $required ? 'required' : '' }}">
-			{{ $label }}
+    <div class="form-group form-element-textaddon {{ $errors->has($name) ? 'has-error' : '' }}">
+        <label for="{{ $name }}" class="control-label {{ $required ? 'required' : '' }}">
+            {{ $label }}
 
-			@if($required)
-				<span class="form-element-required">*</span>
-			@endif
-		</label>
-		<div class="input-group">
-			@if ($placement == 'before')
-				<span class="input-group-addon">{!! $addon !!}</span>
-			@endif
-			<input {!! $attributes !!} value="{{ $value }}">
-			@if ($placement == 'after')
-				<span class="input-group-addon">{!! $addon !!}</span>
-			@endif
-		</div>
+            @if($required)
+                <span class="form-element-required">*</span>
+            @endif
+        </label>
+        <div class="input-group">
+            @if ($placement == 'before')
+                <div class="input-group-prepend">
+                    <span class="input-group-text">{!! $addon !!}</span>
+                </div>
+            @endif
+            <input {!! $attributes !!} value="{{ $value }}">
+            @if ($placement == 'after')
+                <div class="input-group-append">
+                    <span class="input-group-text">{!! $addon !!}</span>
+                </div>
+            @endif
+        </div>
 
-		@include(AdminTemplate::getViewPath('form.element.partials.helptext'))
-		@include(AdminTemplate::getViewPath('form.element.partials.errors'))
-	</div>
+        @include(AdminTemplate::getViewPath('form.element.partials.helptext'))
+        @include(AdminTemplate::getViewPath('form.element.partials.errors'))
+    </div>
 @endif

--- a/src/Form/Element/TextAddon.php
+++ b/src/Form/Element/TextAddon.php
@@ -89,6 +89,10 @@ class TextAddon extends NamedFormElement
             'type' => 'text',
         ]);
 
+        if ($this->isReadonly()) {
+            $this->setHtmlAttribute('disabled', 'disabled');
+        }
+
         return parent::toArray() + [
                 'placement' => $this->getPlacement(),
                 'addon' => $this->getAddon(),


### PR DESCRIPTION
в resources/views/default/form/element/textaddon.blade.php заменен класс и добавлены новы, для корректного отображения в BS4, в стилях все классы уже прописаны, менять не надо
Добавлена возможность к полю textaddon применить setReadOnly()