### PR TITLE
DisplayTab - setId conditions update, DisplayTab external form option, tab title view

### DIFF
--- a/resources/views/default/display/tab.blade.php
+++ b/resources/views/default/display/tab.blade.php
@@ -4,7 +4,7 @@
             {!! $icon !!}
         @endif
 
-        {{ $label }}
+        {!! $label !!}
         @if($badge)
             {!! $badge->render() !!}
         @endif

--- a/src/Display/DisplayTab.php
+++ b/src/Display/DisplayTab.php
@@ -62,6 +62,11 @@ class DisplayTab implements TabInterface, DisplayInterface, FormInterface
     protected $badge;
 
     /**
+     * @var bool
+     */
+    protected $external_form = false;
+
+    /**
      * @var string
      */
     protected $view = 'display.tab';
@@ -315,6 +320,26 @@ class DisplayTab implements TabInterface, DisplayInterface, FormInterface
         }
 
         return $this;
+    }
+
+    /**
+     * @param bool $bool
+     *
+     * @return $this
+     */
+    public function setExternalForm($bool)
+    {
+        $this->external_form = $bool;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getExternalForm()
+    {
+        return $this->external_form;
     }
 
     /**

--- a/src/Display/DisplayTabbed.php
+++ b/src/Display/DisplayTabbed.php
@@ -150,7 +150,7 @@ class DisplayTabbed implements DisplayInterface, FormInterface
      * @param string $label
      * @param bool|false $active
      *
-     * @return TabInterface
+     * @return DisplayTab
      */
     public function appendTab(Renderable $display, $label, $active = false)
     {
@@ -196,9 +196,22 @@ class DisplayTabbed implements DisplayInterface, FormInterface
      */
     public function setId($id)
     {
-        $this->getTabs()->each(function (TabInterface $tab) use ($id) {
+        $model_class = get_class($this->getModel());
+        $this->getTabs()->each(function (TabInterface $tab) use ($id, $model_class) {
             if ($tab instanceof FormInterface) {
-                $tab->setId($id);
+                if (!$tab->getExternalForm()) {
+                    $tab_content = $tab->getContent();
+                    if ($tab_content instanceof FormInterface) {
+                        $tab_model = $tab->getModel();
+                        $tab_model_section = \AdminSection::getModel($tab_model);
+                        if (
+                            $model_class == get_class($tab_model)
+                            && $tab->getContent()->getAction() == $tab_model_section->getUpdateUrl($id)
+                        ) {
+                            $tab->setId($id);
+                        }
+                    }
+                }
             }
         });
 

--- a/src/Display/DisplayTabbed.php
+++ b/src/Display/DisplayTabbed.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Renderable;
 use SleepingOwl\Admin\Traits\VisibleCondition;
 use SleepingOwl\Admin\Contracts\Form\FormInterface;
 use SleepingOwl\Admin\Contracts\Display\TabInterface;
+use SleepingOwl\Admin\Model\SectionModelConfiguration;
 use SleepingOwl\Admin\Contracts\Display\DisplayInterface;
 use SleepingOwl\Admin\Contracts\ModelConfigurationInterface;
 
@@ -203,11 +204,12 @@ class DisplayTabbed implements DisplayInterface, FormInterface
                     $tab_content = $tab->getContent();
                     if ($tab_content instanceof FormInterface) {
                         $tab_model = $tab->getModel();
+                        $set_id = $model_class == get_class($tab_model);
                         $tab_model_section = \AdminSection::getModel($tab_model);
-                        if (
-                            $model_class == get_class($tab_model)
-                            && $tab->getContent()->getAction() == $tab_model_section->getUpdateUrl($id)
-                        ) {
+                        if (is_object($tab_model_section) && $tab_model_section instanceof SectionModelConfiguration) {
+                            $set_id = $set_id && $tab->getContent()->getAction() == $tab_model_section->getUpdateUrl($id);
+                        }
+                        if ($set_id) {
                             $tab->setId($id);
                         }
                     }

--- a/src/Display/DisplayTabbed.php
+++ b/src/Display/DisplayTabbed.php
@@ -200,7 +200,7 @@ class DisplayTabbed implements DisplayInterface, FormInterface
         $model_class = get_class($this->getModel());
         $this->getTabs()->each(function (TabInterface $tab) use ($id, $model_class) {
             if ($tab instanceof FormInterface) {
-                if (!$tab->getExternalForm()) {
+                if (! $tab->getExternalForm()) {
                     $tab_content = $tab->getContent();
                     if ($tab_content instanceof FormInterface) {
                         $tab_model = $tab->getModel();


### PR DESCRIPTION
Имеем код секции, метод onEdit:

```
public function onEdit($id = null, $payload = [])
{
    $model = $id ? \App\Company::find($id) : null;

    $tabs = AdminDisplay::tabbed();

    $main_form = AdminForm::panel()
        ->addBody([
            AdminFormElement::text('title', 'Название')->required(),
        ]);
    $tabs->appendTab($main_form, 'Основное');

    if ($model) {
        $model->load('seo');
        $payload = ['company_id' => $model->id];
        $seo = \AdminSection::getModel(\App\Seo::class);
        $seo = $model->seo
            ? $seo->fireEdit($model->seo->id, $payload)
            : $seo->fireCreate($payload)
        ;
        $tabs->appendTab($seo, 'SEO');
    }

    return $tabs;
```

Данная секция возвращает 2 таба: в первом - простейшая форма редактирования записи о компании, во втором - форма создания или редактирования модели (в зависимости от ее существования) seo-данных записи, которая берется из relation-таблицы и имеет свою секцию. Ниже описание проблемы:

Если метод onEdit секции возвращает табы (элемент DisplayTabbed, набор из нескольких DisplayTab), то для модели каждой формы внутри каждого таба устанавливается id модели из текущей секции - без каких либо проверок и исключений. Однако, за счет того что формы внутри каждого таба по сути никак не связаны, при определенной конфигурации секции в разных табах могут оказаться формы редактирования разных сущностей/моделей/секций: например, в первом табе - форма редактирования основной модели, а во втором табе - форма создания связанной сущности. Без необходимых проверок форме создания записи во втором табе будет установлен id текущей модели (из формы в первом табе), что не приводит к выбрасыванию Exception, но может приводить к программным ошибкам и логическим коллизиям.

В данном PR добавлены необходимые проверки: класс модели в форме внутри таба совпадает с классом текущей редактируемой модели; названия текущей модели и модели в табе, и их id совпадают (по edit url; только при конфигурировании модели через секции). Так же добавлена возможность вручную указать, что форма внутри таба точно не относится к текущей редактируемой записи, через метод `setExternalForm(true)`.