### PR TITLE
added FormCard

### DIFF
--- a/resources/views/default/display/table.blade.php
+++ b/resources/views/default/display/table.blade.php
@@ -7,10 +7,10 @@
 	<br />
 @endif
 
-@yield('before.panel')
+@yield('before.card')
 
-<div class="panel card panel-default {!! $panel_class !!}">
-	<div class="panel-heading card-header">
+<div class="card card-default {!! $panel_class !!}">
+	<div class="card-heading card-header">
 		@if ($creatable)
 			<a href="{{ url($createUrl) }}" class="btn btn-primary">
 				<i class="fas fa-plus"></i> {{ $newEntryButtonText }}
@@ -18,20 +18,20 @@
 		@endif
 
 		<div class="pull-right">
-			@yield('panel.heading.actions')
+			@yield('card.heading.actions')
 		</div>
 
-		@yield('panel.buttons')
+		@yield('card.buttons')
 
 	</div>
 
-	@yield('panel.heading')
+	@yield('card.heading')
 
 	@foreach($extensions as $ext)
 		{!! $ext->render() !!}
 	@endforeach
 
-	@yield('panel.footer')
+	@yield('card.footer')
 </div>
 
 @yield('after.panel')

--- a/resources/views/default/display/tree.blade.php
+++ b/resources/views/default/display/tree.blade.php
@@ -1,18 +1,18 @@
-@yield('before.panel')
+@yield('before.card')
 
-<div class="panel card panel-default {!! $panel_class !!}">
-    <div class="panel-heading card-header">
+<div class="card card-default {!! $panel_class !!}">
+    <div class="card-heading card-header">
         @if ($creatable)
             <a class="btn btn-primary" href="{{ $createUrl }}">
                 <i class="fas fa-plus"></i> {{ $newEntryButtonText }}
             </a>
         @endif
-        @yield('panel.buttons')
+        @yield('card.buttons')
         <div class="pull-right">
-            @yield('panel.heading.actions')
+            @yield('card.heading.actions')
         </div>
 
-        @yield('panel.heading')
+        @yield('card.heading')
     </div>
 
     <div class="card-body">
@@ -24,15 +24,15 @@
           class="btn btn-secondary btn-sm">@lang('sleeping_owl::lang.tree.collapse')</button>
         </menu>
       @endif
-      <div class="panel-body card mt-3">
+      <div class="card-body card mt-3">
         <div class="dd nestable" {!! $attributes !!} data-url="{{ $url }}/reorder">
           <ol class="dd-list">
             @include(AdminTemplate::getViewPath('display.tree_children'), ['children' => $items])
           </ol>
         </div>
       </div>
-      @yield('panel.footer')
+      @yield('card.footer')
     </div>
 
 </div>
-@yield('after.panel')
+@yield('after.card')

--- a/resources/views/default/form/card.blade.php
+++ b/resources/views/default/form/card.blade.php
@@ -1,0 +1,12 @@
+
+    <form {!! $attributes !!}>
+
+        @include(AdminTemplate::getViewPath('form.partials.elements'), ['items' => $items])
+
+        <input type="hidden" name="_method" value="post" />
+        <input type="hidden" name="_redirectBack" value="{{ $backUrl }}" />
+        <input type="hidden" name="_token" value="{{ csrf_token() }}" />
+
+        {!! $buttons->render() !!}
+
+    </form>

--- a/resources/views/default/form/card/element.blade.php
+++ b/resources/views/default/form/card/element.blade.php
@@ -1,0 +1,3 @@
+<div {!! $attributes !!}>
+    @include(AdminTemplate::getViewPath('form.partials.elements'), ['items' => $elements])
+</div>

--- a/src/Contracts/Form/CardInterface.php
+++ b/src/Contracts/Form/CardInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SleepingOwl\Admin\Contracts\Form;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Renderable;
+use SleepingOwl\Admin\Contracts\Initializable;
+
+interface CardInterface extends Initializable, Arrayable, Renderable
+{
+}

--- a/src/Contracts/Form/FormFactoryInterface.php
+++ b/src/Contracts/Form/FormFactoryInterface.php
@@ -9,6 +9,7 @@ use SleepingOwl\Admin\Form;
  * @method Form\FormElements elements(array $elements = [])
  * @method Form\FormTabbed tabbed(array $elements = [])
  * @method Form\FormPanel panel(array $elements = [])
+ * @method Form\FormCard card(array $elements = [])
  */
 interface FormFactoryInterface
 {

--- a/src/Display/DisplayTab.php
+++ b/src/Display/DisplayTab.php
@@ -3,6 +3,7 @@
 namespace SleepingOwl\Admin\Display;
 
 use SleepingOwl\Admin\Form\FormPanel;
+use SleepingOwl\Admin\Form\FormCard;
 use Illuminate\Database\Eloquent\Model;
 use SleepingOwl\Admin\Form\FormDefault;
 use SleepingOwl\Admin\Navigation\Badge;
@@ -185,7 +186,7 @@ class DisplayTab implements TabInterface, DisplayInterface, FormInterface
 
         if ($this->content instanceof FormElements) {
             foreach ($this->content->getElements() as $element) {
-                if ($element instanceof FormDefault && $element instanceof FormPanel) {
+                if ($element instanceof FormDefault && $element instanceof FormCard) {
                     $element->addElement(
                         new FormElements([
                             (new Hidden('sleeping_owl_tab_id'))->setDefaultValue($this->getName()),

--- a/src/Display/DisplayTable.php
+++ b/src/Display/DisplayTable.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Database\Eloquent\Builder;
 use SleepingOwl\Admin\Traits\PanelControl;
+use SleepingOwl\Admin\Traits\CardControl;
 use Illuminate\Pagination\LengthAwarePaginator;
 use SleepingOwl\Admin\Display\Extension\Columns;
 use SleepingOwl\Admin\Display\Extension\ColumnsTotal;
@@ -26,7 +27,7 @@ use SleepingOwl\Admin\Contracts\Display\Extension\ColumnFilterInterface;
  */
 class DisplayTable extends Display
 {
-    use PanelControl;
+    use CardControl, PanelControl;
 
     /**
      * @var string

--- a/src/Factories/FormFactory.php
+++ b/src/Factories/FormFactory.php
@@ -12,6 +12,7 @@ use SleepingOwl\Admin\Contracts\Form\FormFactoryInterface;
  * @method Form\FormElements elements(array $elements = [])
  * @method Form\FormTabbed tabbed(array $elements = [])
  * @method Form\FormPanel panel(array $elements = [])
+ * @method Form\FormCard card(array $elements = [])
  */
 class FormFactory extends AliasBinder implements FormFactoryInterface
 {
@@ -29,6 +30,7 @@ class FormFactory extends AliasBinder implements FormFactoryInterface
             'elements' => Form\FormElements::class,
             'tabbed' => Form\FormTabbed::class,
             'panel' => Form\FormPanel::class,
+            'card' => Form\FormCard::class,
         ]);
     }
 }

--- a/src/Form/Card/Body.php
+++ b/src/Form/Card/Body.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SleepingOwl\Admin\Form\Card;
+
+use SleepingOwl\Admin\Form\FormElements;
+use KodiComponents\Support\HtmlAttributes;
+use SleepingOwl\Admin\Contracts\Form\PanelInterface;
+
+class Body extends FormElements implements PanelInterface
+{
+    use HtmlAttributes;
+
+    /**
+     * @var string
+     */
+    protected $view = 'form.panel.element';
+
+    /**
+     * @var string
+     */
+    protected $class = 'card-body';
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->setHtmlAttribute('class', $this->class);
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return parent::toArray() + [
+                'elements' => $this->getElements()->onlyVisible(),
+                'attributes' => $this->htmlAttributesToString(),
+            ];
+    }
+}

--- a/src/Form/Card/Footer.php
+++ b/src/Form/Card/Footer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SleepingOwl\Admin\Form\Card;
+
+class Footer extends Body
+{
+    /**
+     * @var string
+     */
+    protected $class = 'card-footer';
+}

--- a/src/Form/Card/Header.php
+++ b/src/Form/Card/Header.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SleepingOwl\Admin\Form\Card;
+
+class Header extends Body
+{
+    /**
+     * @var string
+     */
+    protected $class = 'card-header';
+}

--- a/src/Form/FormCard.php
+++ b/src/Form/FormCard.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace SleepingOwl\Admin\Form;
+
+use SleepingOwl\Admin\Contracts\Form\FormElementInterface;
+use SleepingOwl\Admin\Form\Card\Body;
+use SleepingOwl\Admin\Form\Card\Footer;
+use SleepingOwl\Admin\Form\Card\Header;
+use SleepingOwl\Admin\Form\Element\Html;
+use SleepingOwl\Admin\Traits\CardControl;
+
+class FormCard extends FormDefault
+{
+    use CardControl;
+
+    const POSITION_HEADER = 'header';
+    const POSITION_BODY   = 'body';
+    const POSITION_FOOTER = 'footer';
+
+    //   const SEPARATOR = '<hr class="panel-wide" />';
+    const SEPARATOR = '';
+
+    /**
+     * @var string
+     */
+    protected $view = 'form.card';
+
+    /**
+     * FormCard constructor.
+     *
+     * @param array $elements
+     */
+    public function __construct(array $elements = [])
+    {
+        parent::__construct($elements);
+
+        $this->setCardClass('card');
+    }
+
+    /**
+     * Initialize form.
+     */
+    public function initialize()
+    {
+        $this->getButtons()->setHtmlAttribute('class', 'card-footer');
+
+        $this->setHtmlAttribute('class', 'card ' . $this->getCardClass());
+
+        parent::initialize();
+    }
+
+    /**
+     * @param array|FormElementInterface $items
+     *
+     * @return $this
+     */
+    public function setItems($items)
+    {
+        if (!is_array($items))
+        {
+            $items = func_get_args();
+        }
+
+        $this->addBody($items);
+
+        return $this;
+    }
+
+    /**
+     * @param FormElementInterface $item
+     *
+     * @return $this
+     */
+    public function addItem($item)
+    {
+        if ($part = $this->getElements()->last())
+        {
+            $part->addElement($item);
+        } else
+        {
+            $this->addBody($item);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array|FormElementInterface $items
+     *
+     * @return $this
+     */
+    public function addHeader($items)
+    {
+        if (!is_array($items))
+        {
+            $items = func_get_args();
+        }
+
+        $this->addElement(new Header($items));
+
+        return $this;
+    }
+
+    /**
+     * @param array|FormElementInterface $items
+     *
+     * @return $this
+     */
+    public function addBody($items)
+    {
+        if (!is_array($items))
+        {
+            $items = func_get_args();
+        }
+
+        $class = $this->getElements()->last();
+        if (is_object($class) && get_class($class) === Body::class)
+        {
+            $this->addElement(new Html('<hr />'));
+        }
+
+        $this->addElement(new Body($items));
+
+        return $this;
+    }
+
+    /**
+     * @param array|FormElementInterface $items
+     *
+     * @return $this
+     */
+    public function addFooter($items)
+    {
+        if (!is_array($items))
+        {
+            $items = func_get_args();
+        }
+
+        $this->addElement(new Footer($items));
+
+        return $this;
+    }
+}

--- a/src/Form/FormTabbed.php
+++ b/src/Form/FormTabbed.php
@@ -2,11 +2,11 @@
 
 namespace SleepingOwl\Admin\Form;
 
-use SleepingOwl\Admin\Traits\PanelControl;
+use SleepingOwl\Admin\Traits\CardControl;
 
 class FormTabbed extends FormDefault
 {
-    use PanelControl;
+    use CardControl;
 
     /**
      * @var string
@@ -22,7 +22,7 @@ class FormTabbed extends FormDefault
     {
         parent::__construct($elements);
 
-        $this->setPanelClass('panel-form-tabbed');
+        $this->setCardClass('card-form-tabbed');
     }
 
     /**
@@ -30,9 +30,9 @@ class FormTabbed extends FormDefault
      */
     public function initialize()
     {
-        $this->getButtons()->setHtmlAttribute('class', 'panel-footer');
+        $this->getButtons()->setHtmlAttribute('class', 'card-footer');
 
-        $this->setHtmlAttribute('class', 'panel panel-default '.$this->getPanelClass());
+        $this->setHtmlAttribute('class', 'card card-default '.$this->getCardClass());
 
         parent::initialize();
     }

--- a/src/Traits/CardControl.php
+++ b/src/Traits/CardControl.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SleepingOwl\Admin\Traits;
+
+trait CardControl
+{
+    /**
+     * @var string|null
+     */
+    protected $cardClass = null;
+
+    /**
+     * @return string
+     */
+    public function getCardClass()
+    {
+        return $this->cardClass;
+    }
+
+    /**
+     * @param string $class
+     *
+     * @return $this
+     */
+    public function setCardClass($class)
+    {
+        $this->cardClass = $class;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
**Добавлено FormCard (по аналогии с FormPanel)**
Добавлены необходимые классы и дополнены существующие, ничего не сломано

В BS4 panel панель заменено на card, все стили для card (card-header, card-body, card-footer) в пакете уже есть а элемента формы не было.

Просьба почистить переназначение в стилях, прилипает к краям, пропадает отступ
убрать строки 
```
.card-body {
    padding: 0 0 1.25em;
}
```
оставить только 
```
.card-body {
    flex: 1 1 auto;
    padding: 1.25rem;
}
```
по возможности пересмотреть padding, как по мне они лишние
```
 .tab-content {
    padding-bottom: 1em;
    padding-top: 1em;  
}
form .form-buttons {
    padding-bottom: 2em;
}
```