### PR TITLE
Fix AdminColumnFilter::text()->setOperator('in')

### DIFF
--- a/src/Traits/SqlQueryOperators.php
+++ b/src/Traits/SqlQueryOperators.php
@@ -86,12 +86,17 @@ trait SqlQueryOperators
                 break;
             case 'whereBetween':
             case 'whereNotBetween':
-                $query->{$method}($column, (array) $value);
+                if (!is_array($value)) {
+                    $value = explode(',', $value);
+                }
+                $query->{$method}($column, $value);
                 break;
             case 'whereIn':
             case 'whereNotIn':
-
-                $query->{$method}($column, (array) $value);
+                if (!is_array($value)) {
+                    $value = explode(',', $value);
+                }
+                $query->{$method}($column, $value);
                 break;
         }
     }


### PR DESCRIPTION
добавлена возможность при использовании AdminColumnFilter::text()->setOperator('in') вводить значения через запятую для фильтра по массиву
в классе src/Traits/SqlQueryOperators.php метод buildQuery дополнен по аналогии с методом prepareValue