### PR TITLE
Fix for case when primary key field name is other than 'id'.

### DIFF
--- a/src/Http/Controllers/FormElementController.php
+++ b/src/Http/Controllers/FormElementController.php
@@ -256,7 +256,7 @@ class FormElementController extends Controller
 
                             return [
                                 'tag_name' => $value,
-                                'id' => $item->id,
+                                'id' => $item->{$item->getKeyName()},
                                 'custom_name' => $custom_name_value,
                             ];
                         })


### PR DESCRIPTION
If model has some $primaryKey value different from 'id', selectajax form element has unselectable items because of null value of id field of json answer from backend. For example: [{"tag_name":"BOSCH (id=3)","id":null,"custom_name":null},{"tag_name":"BOSCH \u0411\u044b\u0442\u043e\u0432\u0430\u044f \u0442\u0435\u0445\u043d\u0438\u043a\u0430 (id=646)","id":null,"custom_name":null},{"tag_name":"BOSCH \u0410\u0432\u0442\u043e\u0442\u043e\u0432\u0430\u0440\u044b (id=1301)","id":null,"custom_name":null},{"tag_name":"BOSCH PETFOOD (id=1845)","id":null,"custom_name":null}]

With fix from this PR problem is solved, json is like [{"tag_name":"BOSCH (id=3)","id":3,"custom_name":null},{"tag_name":"BOSCH \u0411\u044b\u0442\u043e\u0432\u0430\u044f \u0442\u0435\u0445\u043d\u0438\u043a\u0430 (id=646)","id":646,"custom_name":null},{"tag_name":"BOSCH \u0410\u0432\u0442\u043e\u0442\u043e\u0432\u0430\u0440\u044b (id=1301)","id":1301,"custom_name":null},{"tag_name":"BOSCH PETFOOD (id=1845)","id":null,"custom_name":null}] and options are selectable.