### PR TITLE
Fix sorting

### DIFF
--- a/src/Providers/AdminServiceProvider.php
+++ b/src/Providers/AdminServiceProvider.php
@@ -223,7 +223,7 @@ class AdminServiceProvider extends ServiceProvider
             ->notName('navigation.php')
             ->in($directory)
             ->sort(function (SplFileInfo $a) {
-                return $a->getFilename() != 'bootstrap.php';
+                return $a->getFilename() === 'bootstrap.php' ? -1 : 1;
             });
 
         foreach ($files as $file) {


### PR DESCRIPTION
Fixed PHP 8 error "Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero"