### PR TITLE
Fix for unique validation of field for model with primary case different from default 'id'.

### DIFF
--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -357,10 +357,9 @@ abstract class NamedFormElement extends FormElement
             }
 
             $model = $this->resolvePath();
-            $table = $model->getTable();
             $connection = $model->getConnectionName();
 
-            $rule = 'unique:'.$connection.'.'.$table.','.$this->getModelAttributeKey();
+            $rule = 'unique:'.$connection.'.'.get_class($model).','.$this->getModelAttributeKey();
             if ($model->exists) {
                 $rule .= ','.$model->getKey();
             }


### PR DESCRIPTION
If we pass full model name, Laravel's validator gets table name in \Illuminate\Validation\Concerns\ValidatesAttributes::parseTable. Otherwise (if we pass direct table name instead of model name) we will get error "Column not found: 1054 Unknown column 'id' in 'where clause'" or logic error of validation if such field exists.

With this fix Laravel will retrieve primary key field by itself.