### PR TITLE
feat: add ability to save nested level of relations

### DIFF
--- a/src/Form/FormDefault.php
+++ b/src/Form/FormDefault.php
@@ -354,11 +354,8 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
         }
 
         parent::save($request);
-        $this->saveBelongsToRelations($model);
 
-        $model->save();
-
-        $this->saveHasOneRelations($model);
+        $this->saveWithRelations($model);
 
         parent::afterSave($request);
 
@@ -366,6 +363,13 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
         $this->getModelConfiguration()->fireEvent('saved', false, $model);
 
         return true;
+    }
+
+    protected function saveWithRelations(Model $model)
+    {
+        $this->saveBelongsToRelations($model);
+        $model->save();
+        $this->saveHasOneRelations($model);
     }
 
     /**
@@ -376,7 +380,7 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
     {
         foreach ($model->getRelations() as $name => $relation) {
             if ($model->{$name}() instanceof BelongsTo && ! is_null($relation)) {
-                $relation->save();
+                $this->saveWithRelations($relation);
                 $model->{$name}()->associate($relation);
             }
         }
@@ -391,9 +395,13 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
         foreach ($model->getRelations() as $name => $relation) {
             if ($model->{$name}() instanceof HasOneOrMany && ! is_null($relation)) {
                 if (is_array($relation) || $relation instanceof \Traversable) {
-                    $model->{$name}()->saveMany($relation);
+                    $childModels = $model->{$name}()->saveMany($relation);
+                    foreach ($childModels as $childModel){
+                        $this->saveWithRelations($childModel);
+                    }
                 } else {
-                    $model->{$name}()->save($relation);
+                    $childModel = $model->{$name}()->save($relation);
+                    $this->saveWithRelations($childModel);
                 }
             }
         }

--- a/src/Form/FormDefault.php
+++ b/src/Form/FormDefault.php
@@ -396,7 +396,7 @@ class FormDefault extends FormElements implements DisplayInterface, FormInterfac
             if ($model->{$name}() instanceof HasOneOrMany && ! is_null($relation)) {
                 if (is_array($relation) || $relation instanceof \Traversable) {
                     $childModels = $model->{$name}()->saveMany($relation);
-                    foreach ($childModels as $childModel){
+                    foreach ($childModels as $childModel) {
                         $this->saveWithRelations($childModel);
                     }
                 } else {

--- a/tests/Admin/Form/Element/NamedFormElementTest.php
+++ b/tests/Admin/Form/Element/NamedFormElementTest.php
@@ -374,10 +374,7 @@ class NamedFormElementTest extends TestCase
 
         $this->assertEquals($model, $this->callMethodByPath($element, 'key'));
 
-        $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
-        $model->shouldReceive('getAttribute')->with('key')->andReturn('test');
-
-        $this->assertNull($this->callMethodByPath($element, 'key.key1'));
+        // -------------
 
         $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
         $model->shouldReceive('getAttribute')
@@ -385,10 +382,37 @@ class NamedFormElementTest extends TestCase
             ->andReturn($model1 = m::mock(\Illuminate\Database\Eloquent\Model::class));
 
         $this->assertEquals($model1, $this->callMethodByPath($element, 'key.key1'));
+
+        // -------------
+
+        $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
+        $model->shouldReceive('getAttribute')
+            ->with('firstRelation')
+            ->andReturn($model1 = m::mock(\Illuminate\Database\Eloquent\Model::class));
+
+        $model1->shouldReceive('getAttribute')
+            ->with('secondRelation')
+            ->andReturn($model2 = m::mock(\Illuminate\Database\Eloquent\Model::class));
+
+        $model2->shouldReceive('getAttribute')
+            ->with('key1');
+        $this->assertEquals($model2, $this->callMethodByPath($element, 'firstRelation.secondRelation.key1'));
     }
 
     public function test_get_model_by_path_exception()
     {
+        $element = $this->getElement('key', 'Label');
+
+        // -------------
+
+        $this->expectException(LogicException::class);
+        $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
+        $model->shouldReceive('getAttribute')->with('key')->andReturn('test');
+
+        $this->assertNull($this->callMethodByPath($element, 'key.key1'));
+
+
+        // -------------
         $this->expectException(LogicException::class);
         $element = $this->getElement('key', 'Label');
 

--- a/tests/Admin/Form/Element/NamedFormElementTest.php
+++ b/tests/Admin/Form/Element/NamedFormElementTest.php
@@ -411,8 +411,8 @@ class NamedFormElementTest extends TestCase
 
         $this->assertNull($this->callMethodByPath($element, 'key.key1'));
 
-
         // -------------
+
         $this->expectException(LogicException::class);
         $element = $this->getElement('key', 'Label');
 


### PR DESCRIPTION
Изменения
В `NamedFormElement.php` последнюю часть после . считаю всегда названием поля и отбрасываю ее при помощи array_pop, по всем остальным прохожусь циклом и падаю с ошибкой если не получается какую-нибудь из связей разрезолвить.

При сохранении вызываю `saveBelongsToRelations` и `saveHasOneRelations` рекурсивно для всех моделей. Скорее всего не будет работать при `->hasOne->belongsTo`, когда belongsTo еще не создана

В тестах:
Этот код теперь выбрасывает исключение (так как ожидается что `key` вернет модель). Его перенес в 
метод `test_get_model_by_path_exception`
```php
        $element->setModel($model = m::mock(\Illuminate\Database\Eloquent\Model::class));
        $model->shouldReceive('getAttribute')->with('key')->andReturn('test');

        $this->assertNull($this->callMethodByPath($element, 'key.key1'));
```


