### PR TITLE
Date range filter works fine with nullable fields now.

### DIFF
--- a/src/Display/Column/Filter/DateRange.php
+++ b/src/Display/Column/Filter/DateRange.php
@@ -35,14 +35,14 @@ class DateRange extends Date
     /**
      * @param  string  $date
      * @param  bool  $add_day
-     * @return array|string
+     * @return array|void
      *
      * @throws \SleepingOwl\Admin\Exceptions\FilterOperatorException
      */
     public function parseValue($date, $add_day = false)
     {
         if ($date === null) {
-            return ['0000-00-00', '9999-12-31'];
+            return;
         }
 
         $dates = explode(' - ', $date, 2);


### PR DESCRIPTION
Old behavior: filter adds interval '0000-00-00' - '9999-12-31' by default, so, null isn't in this range and rows with null-value in filtered field is out of query result.

But if user didn't choose any date, they don't care about value necessity, value might be null, less than 0000-00-00 etc.

New behavior: until user chooses smth in filter, it won't be applied to DB query. 