### PR TITLE
fix(element): set default value for select with json field

### DIFF
--- a/src/Form/Element/NamedFormElement.php
+++ b/src/Form/Element/NamedFormElement.php
@@ -452,7 +452,7 @@ abstract class NamedFormElement extends FormElement
                 $jsonAttr = json_decode($jsonAttr, true);
             }
 
-            return Arr::get($jsonAttr, $jsonParts->slice(1)->implode('.'));
+            return Arr::get($jsonAttr, $jsonParts->slice(1)->implode('.'), $value);
         }
 
         $relations = explode('.', $path);


### PR DESCRIPTION
Если у Select стоит json-поле, не работает установка значения по умолчанию.

Пример:
```php
AdminFormElement::select('setting_parsing->currency', 'Исходная валюта')
                    ->setOptions([
                        'RUB' => 'RUB',
                        'USD' =>'USD',
                    ])
                    ->setDefaultValue('RUB')
```