### PR TITLE
fix(inline-edit): if column is found, stop searching

### DIFF
--- a/src/Http/Controllers/AdminController.php
+++ b/src/Http/Controllers/AdminController.php
@@ -524,6 +524,8 @@ class AdminController extends Controller
         } else {
             if ($display instanceof DisplayTabbed) {
                 foreach ($display->getTabs() as $tab) {
+                    if($column) continue;
+                    
                     $content = $tab->getContent();
 
                     if ($content instanceof DisplayTable) {


### PR DESCRIPTION
Речь про AdminColumnEditable. При inline редактировании сова ищет необходимый столбец, но когда его не находит не останавливается и продолжает искать его на следующих табах, из-за чего по итогу он может сбиться.

Исправил тем, что останавливаю перебор в случае нахождения столбца.