### PR TITLE
Fix inverted class_exists guard for IdeHelper provider on ia11 (#1433)

### DIFF
--- a/src/Providers/SleepingOwlServiceProvider.php
+++ b/src/Providers/SleepingOwlServiceProvider.php
@@ -65,7 +65,7 @@ class SleepingOwlServiceProvider extends AdminSectionsServiceProvider
     protected function registerCommands()
     {
         if ($this->app->runningInConsole()) {
-            if (! class_exists('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider') &&
+            if (class_exists('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider') &&
                 ! $this->app->resolved('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider')) {
                 $this->app->register('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider');
             }


### PR DESCRIPTION
Fixes #1433

## Problem

On `ia11`, `SleepingOwlServiceProvider::registerCommands()` has an **inverted** `class_exists()` guard:

```php
if (! class_exists('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider') &&
    ! $this->app->resolved('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider')) {
    $this->app->register('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider');
}
```

The provider is registered **exactly when the class does NOT exist**. `barryvdh/laravel-ide-helper` is only a `require-dev` dependency, so it is absent in downstream installs — and every artisan command fatals with:

```
Class "Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider" not found
```

(thrown from `Illuminate\Foundation\Application::register()`).

## Fix

Register the provider only when its class actually exists (drop the leading `!`):

```php
if (class_exists('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider') &&
    ! $this->app->resolved('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider')) {
    $this->app->register('Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider');
}
```

One-line logic change; no reformatting.

## Reproduction

1. Fresh Laravel 10–13 app.
2. `composer require laravelrus/sleepingowl:dev-ia11` without `barryvdh/laravel-ide-helper`.
3. Run any artisan command (`php artisan package:discover`, `php artisan route:list`) → fatal "class not found".

With this change, the provider is skipped when the dev tool isn't installed and still registered when it is.
