### PR TITLE
Fix Meta::putGlobalVar() missing implementation

### DIFF
--- a/src/Templates/Meta.php
+++ b/src/Templates/Meta.php
@@ -6,4 +6,8 @@ use SleepingOwl\Admin\Contracts\Template\MetaInterface;
 
 class Meta extends \KodiCMS\Assets\Meta implements MetaInterface
 {
+    public function putGlobalVar($var, $value)
+    {
+        return $this->assets()->putGlobalVar($var, $value);
+    }
 }


### PR DESCRIPTION
## Problem
On release `10.48.29`, `php artisan package:discover` / `composer install` fails:
Class SleepingOwl\Admin\Templates\Meta contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (SleepingOwl\Admin\Contracts\Template\MetaInterface::putGlobalVar)
`MetaInterface` declares `putGlobalVar()`, but `SleepingOwl\Admin\Templates\Meta` is empty.

## Solution
Delegate `putGlobalVar()` to the assets manager (same pattern as other KodiCMS Meta methods).

## Reproduction
- Laravel 10.x
- `laravelrus/sleepingowl` 10.48.29
- `php artisan package:discover`