### PR TITLE
Use is_null() for the :limit binding so disableCreation() keeps hiding the Add button (ia11)

### DIFF
--- a/resources/views/default/form/element/related/elements.blade.php
+++ b/resources/views/default/form/element/related/elements.blade.php
@@ -2,7 +2,7 @@
     inline-template
     name="{{ $name }}"
     label="{{ $label }}"
-    @if (!empty($limit))
+    @if (!is_null($limit))
         :limit="{{ (int) $limit }}"
     @endif
     :initial-groups-count="{{ (int)$groups->count() }}"

--- a/resources/views/default/form/element/related/elements_without_card.blade.php
+++ b/resources/views/default/form/element/related/elements_without_card.blade.php
@@ -2,7 +2,7 @@
     inline-template
     name="{{ $name }}"
     label="{{ $label }}"
-    @if (!empty($limit))
+    @if (!is_null($limit))
         :limit="{{ (int) $limit }}"
     @endif
     :initial-groups-count="{{ (int)$groups->count() }}"


### PR DESCRIPTION
> **Note:** reworked after b8db1666bd / b37523748e — the original problem this PR targeted (Add button missing when no limit is set) is already fixed on current `ia11`, thanks! The PR is now rebased onto `ia11` HEAD and reduced to a one-word change covering the remaining edge case.

## Problem

`disableCreation()` (= `setLimit(0)`) no longer hides the Add button on current `ia11` (8a63bbfd).

## Cause

Both related-element views bind the prop with

```blade
@if (!empty($limit))
    :limit="{{ (int) $limit }}"
@endif
```

`empty(0) === true`, so `setLimit(0)` skips the binding entirely. Without the prop, `canAddMore()` falls back to `true` and the Add button is rendered even though creation is disabled — the very case cd84ca96 ("fix disableCreation method in hasMany elements") originally fixed.

## Fix

`!empty($limit)` → `!is_null($limit)` in both views:

- limit not set (`null`) → prop absent → Add button visible (current behaviour kept);
- `setLimit(N)` → `:limit="N"` → works as now;
- `setLimit(0)` / `disableCreation()` → `:limit="0"` → button hidden (cd84ca96 behaviour restored).

Blade-only change, no JS rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
