### PR TITLE
Fix column filters dropping the literal 0 value on ia11 (#1437)

### DIFF
--- a/src/Display/Column/Filter/BaseColumnFilter.php
+++ b/src/Display/Column/Filter/BaseColumnFilter.php
@@ -149,7 +149,7 @@ abstract class BaseColumnFilter implements Renderable, ColumnFilterInterface, Ar
             return;
         }
 
-        if (empty($queryString) && ! $queryString) {
+        if (empty($queryString) && $queryString !== '0' && $queryString !== 0) {
             return;
         }
 

--- a/tests/Admin/Display/Column/Filter/BaseColumnFilterTest.php
+++ b/tests/Admin/Display/Column/Filter/BaseColumnFilterTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Mockery as m;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use SleepingOwl\Admin\Contracts\Display\ColumnInterface;
 use SleepingOwl\Admin\Display\Column\Filter\BaseColumnFilter;
 
@@ -78,6 +80,67 @@ class BaseColumnFilterTest extends TestCase
         });
 
         $filter->apply($column, $builder, 'keyword', []);
+    }
+
+    /**
+     * The literal zero is a selectable filter value (`0 => 'No'`), not "nothing selected".
+     */
+    #[DoesNotPerformAssertions]
+    public function testApplyKeepsZeroValue()
+    {
+        $column = m::mock(ColumnInterface::class);
+        $column->shouldReceive('getMetaData')->once()->andReturn(null);
+        $column->shouldReceive('getFilterCallback')->once()->andReturn(null);
+        $column->shouldReceive('getName')->andReturn('columnName');
+
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $builder->shouldReceive('where')->once()->withArgs(['columnName', '=', '0']);
+
+        $this->getPlainFilter()->apply($column, $builder, '0', []);
+    }
+
+    /**
+     * @param  mixed  $value
+     */
+    #[DataProvider('emptyValuesProvider')]
+    #[DoesNotPerformAssertions]
+    public function testApplySkipsEmptyValue($value)
+    {
+        $column = m::mock(ColumnInterface::class);
+        $column->shouldReceive('getMetaData')->once()->andReturn(null);
+        $column->shouldReceive('getFilterCallback')->once()->andReturn(null);
+        $column->shouldReceive('getName')->andReturn('columnName');
+
+        $builder = m::mock(\Illuminate\Database\Eloquent\Builder::class);
+        $builder->shouldNotReceive('where');
+
+        $this->getPlainFilter()->apply($column, $builder, $value, []);
+    }
+
+    public static function emptyValuesProvider()
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'empty array' => [[]],
+            'false' => [false],
+        ];
+    }
+
+    /**
+     * A bare filter with the default `equal` operator, without the asset package
+     * initialization the constructor does — `apply()` does not need it.
+     *
+     * @return BaseColumnFilter
+     */
+    protected function getPlainFilter()
+    {
+        return new class extends BaseColumnFilter
+        {
+            public function __construct()
+            {
+            }
+        };
     }
 
     public function sqlOperatorsProvider()


### PR DESCRIPTION
Fixes #1437

## Problem

`BaseColumnFilter::apply()` treats the literal `0` as "nothing selected" and returns before building the where clause, so a filter set to that value applies **no condition at all** — the datatable comes back with the full, unfiltered list.

```php
if (empty($queryString) && ! $queryString) {
    return;
}
```

The request carries such a value as the string `"0"`, for which `empty("0")` and `! "0"` are both true.

In practice this breaks every `AdminColumnFilter::select()` with an option keyed `0`:

```php
AdminColumnFilter::select()
    ->setColumnName('visible')
    ->setOptions([1 => 'Yes', 0 => 'No'])
    ->setPlaceholder('Published?'),
```

Picking **Yes** works, picking **No** lists everything.

## Cause

A regression against 9.5.1, where the guard read:

```php
if (empty($queryString) && strlen($queryString) == 0) {
```

`"0"` is `empty()`, but `strlen("0") == 0` is false, so the value passed through. Commit d5821417 ("Fix 8.1 warning deprecations part1") replaced `strlen($queryString) == 0` with `! $queryString` to silence the `strlen(null)` deprecation under PHP 8.1 — but for a defined variable `! $x` is exactly equivalent to `empty($x)`, so the second condition became dead weight and the zero case was lost with it.

## Fix

Keep the deprecation fix (no `strlen()` on a possibly-null value), exclude the literal zero from the "nothing selected" test:

```php
if (empty($queryString) && $queryString !== '0' && $queryString !== 0) {
    return;
}
```

Everything previously skipped (`null`, `''`, `[]`, `false`) is still skipped; only the zero value now reaches the query builder, as it did in 9.5.1. No new query shapes appear either — the affected filters already run this code path for their non-zero options.

One-line logic change; no reformatting.

## Tests

`tests/Admin/Display/Column/Filter/BaseColumnFilterTest.php`:

- `testApplyKeepsZeroValue` — `"0"` reaches the builder as `where('columnName', '=', '0')`; fails without the fix, since `where()` is never called.
- `testApplySkipsEmptyValue` — `null`, `''`, `[]` and `false` still short-circuit and touch no builder method.

## Running the new tests

The rest of `BaseColumnFilterTest` does not run on the PHPUnit the package currently resolves to (13.x): `@dataProvider` docblock annotations are no longer honoured and `getMockForAbstractClass()` was removed in 12. That is pre-existing and out of scope here, so the two new cases avoid both — they use `#[DataProvider]` / `#[DoesNotPerformAssertions]` attributes (supported since PHPUnit 10) and a plain anonymous subclass instead of the abstract-class mock helper.

Verified locally with

```
vendor/bin/phpunit --no-configuration --bootstrap <autoload + tests/TestCase.php> \
    --filter "testApplyKeepsZeroValue|testApplySkipsEmptyValue" \
    tests/Admin/Display/Column/Filter/BaseColumnFilterTest.php
```

5 cases pass with the fix; without it `testApplyKeepsZeroValue` fails with `Method where('columnName', '=', '0') ... should be called exactly 1 times but called 0 times`. (The ad-hoc bootstrap is needed because `tests/TestCase.php` declares a global `TestCase` that the `SleepingOwl\Tests\` PSR-4 mapping does not cover — also pre-existing.)

## Note

The same line is on `development`; happy to open the identical PR there if wanted.
