### PR TITLE
Fix multiple selectajax marking only the first stored value as selected on ia11 (#1440)

### DIFF
--- a/resources/views/default/form/element/selectajax.blade.php
+++ b/resources/views/default/form/element/selectajax.blade.php
@@ -10,7 +10,8 @@
 
         <div>
             {{--            {!! Form::select($name, $options, $value, $attributes) !!}--}}
-            {!! html()->select($name, $options, $value)->attributes($attributes) !!}
+            @php($select = html()->select($name, $options, $value)->attributes($attributes))
+            {!! $select->hasAttribute('multiple') ? $select->multiple() : $select !!}
         </div>
 
         @include(AdminTemplate::getViewPath('form.element.partials.helptext'))


### PR DESCRIPTION
Fixes #1440

## Problem

A multiple `selectajax` renders only its **first** stored value as `selected`. The remaining values are present as options but unselected.

That is not just cosmetic. The browser submits what is selected, and `ElementSaveRelation::afterSave()` syncs the relation with exactly that:

```php
$relation->sync($values);
```

So opening a record and pressing Save — without touching the field — deletes every related row but one. A user account holding 10 roles rendered 1 selected role.

## Cause

`resources/views/default/form/element/selectajax.blade.php:13`:

```php
{!! html()->select($name, $options, $value)->attributes($attributes) !!}
```

`Html::select()` applies the value straight away (`Select::value()` → `Select::applyValueToOptions()`), and that method truncates the value set when the element is not marked multiple:

```php
if (! $this->hasAttribute('multiple')) {
    $value = $value->take(1);
}
```

`multiple` only arrives on the next call, from `->attributes($attributes)`, and `BaseElement::attributes()` never recomputes the selection — so `take(1)` wins permanently. The rendered tag is still a correct `<select multiple>`, which is why the markup looks fine while a single option carries `selected`.

A regression against the pre-`spatie/laravel-html` code — the previous line is still there as a comment right above:

```php
{{-- {!! Form::select($name, $options, $value, $attributes) !!} --}}
```

`laravelcollective/html` took attributes and value in one call, so `multiple` was known before the selection was computed.

## Fix

Put `multiple` on the element before the value is applied. `Select::multiple()` re-runs `applyValueToOptions()` itself, so the stored value — including one restored from old input — is re-applied against the full option list:

```php
@php($select = html()->select($name, $options, $value)->attributes($attributes))
{!! $select->hasAttribute('multiple') ? $select->multiple() : $select !!}
```

The single-select path is untouched: with no `multiple` attribute the ternary returns the element unchanged, and `take(1)` remains correct there.

`Select::multiple()` also normalises the name to `foo[]`, which `MultiSelect::getName()` has already done — the append is guarded by `Str::endsWith($name, '[]')`, so nothing changes.

Verified against a `BelongsToMany` with 10 rows: 10 options, 10 `selected`, and a single-value `selectajax` on the same form still renders exactly one. The line is identical on `development` — happy to port it there too.
