### PR TITLE
Fix SelectAjax empty-value fallback loading null-key rows as options on ia11 (#1441)

### DIFF
--- a/src/Form/Element/SelectAjax.php
+++ b/src/Form/Element/SelectAjax.php
@@ -64,7 +64,7 @@ class SelectAjax extends Select implements Initializable, WithRoutesInterface
                 return $query->where([$key => $default_value]);
             }
 
-            return $query->where([$key => null]);
+            return $query->whereIn($key, []);
         };
 
         $this->setLanguage(config('app.locale'));


### PR DESCRIPTION
Fixes #1441

## Problem

When a `selectajax` has no value, its option query falls back to `WHERE <primary key> IS NULL`. The intent is "nothing selected, so preload no options", but that condition is not empty — it matches every row whose key is null and loads them as options.

Result on an ordinary admin page: junk options with an empty `id`, plus one `Using null as an array offset` deprecation per matched row, raised inside `Arr::pluck()` while `loadOptions()` builds the `KEY => VALUE` pairs. One element produced ~280 deprecations/day on our production.

## Cause

`src/Form/Element/SelectAjax.php:67`, in the default query preparer set up by the constructor:

```php
return $query->where([$key => null]);
```

`where([$key => null])` compiles to `where <pk> is null`, not to "no rows".

`MultiSelectAjax` already expresses the same fallback correctly:

```php
return $query->whereIn($key, []);
```

so the two sibling elements disagree about how to say "match nothing".

## Fix

Use the sibling's expression:

```php
-            return $query->where([$key => null]);
+            return $query->whereIn($key, []);
```

`whereIn(..., [])` compiles to `0 = 1`, so the fallback returns an empty option list under all circumstances.

Worth noting this cannot be worked around from the application side — `SelectAjax::toArray()` overwrites any custom `setLoadOptionsQueryPreparer()` with `default_query_preparer` before the options are loaded:

```php
public function toArray(): array
{
    $this->setLoadOptionsQueryPreparer($this->default_query_preparer);
```

One-line change, no behaviour change for elements whose options table has no null-key rows.
