### PR TITLE
Fix null passed to strpos() and preg_replace() in Range filter and Wysiwyg DummyFilter on ia11 (#1442)

### DIFF
--- a/src/Display/Column/Filter/Range.php
+++ b/src/Display/Column/Filter/Range.php
@@ -115,7 +115,7 @@ class Range extends BaseColumnFilter
      */
     public function parseValue($range)
     {
-        if (strpos($range, '::') === false) {
+        if (strpos((string) $range, '::') === false) {
             return;
         }
 

--- a/src/Wysiwyg/DummyFilter.php
+++ b/src/Wysiwyg/DummyFilter.php
@@ -14,7 +14,7 @@ class DummyFilter implements WysiwygFilterInterface
     public function apply($text)
     {
         return Blade::compileString(
-            preg_replace(['/<(\?|\%)\=?(php)?/', '/(\%|\?)>/'], ['', ''], $text)
+            preg_replace(['/<(\?|\%)\=?(php)?/', '/(\%|\?)>/'], ['', ''], (string) $text)
         );
     }
 }


### PR DESCRIPTION
Fixes #1442

## Problem

Two spots pass a possibly-null value into a string parameter and emit PHP 8.1+ deprecations on completely ordinary admin pages — an unfilled range column filter and an empty wysiwyg field:

```
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
    src/Display/Column/Filter/Range.php:118

preg_replace(): Passing null to parameter #3 ($subject) of type string is deprecated
    src/Wysiwyg/DummyFilter.php:17
```

Nothing breaks functionally, but the volume is real: these two were the largest remaining source in our PHP warning log after third-party vendor deprecations, ~600 entries/day. They also cannot be silenced from the application — both values originate inside SleepingOwl's own filter/form layer.

## Cause

`Range::parseValue()` is called by `BaseColumnFilter::apply()` for the column filter of every rendered row set, and its argument is null whenever the range filter was not filled in — the normal state of a freshly opened section.

`DummyFilter::apply()` receives null whenever the edited record's wysiwyg field is empty — the normal state for a new record or an optional field. Its docblock already declares `@param string $text`, so null is out of contract; it arrives anyway from the form layer.

## Fix

Cast to string at the point of use:

```php
-        if (strpos($range, '::') === false) {
+        if (strpos((string) $range, '::') === false) {
```

```php
-            preg_replace(['/<(\?|\%)\=?(php)?/', '/(\%|\?)>/'], ['', ''], $text)
+            preg_replace(['/<(\?|\%)\=?(php)?/', '/(\%|\?)>/'], ['', ''], (string) $text)
```

Behaviour is unchanged in both cases:

* `strpos('', '::')` is `false`, so `parseValue()` returns void for a null range exactly as before;
* `preg_replace(..., '')` returns `''`, and `Blade::compileString('')` returns `''` — which is what the null path effectively produced already.

Both lines are identical on `development` — happy to port it there too.
