### PR TITLE
Guard the sleepingowl:ide:generate command registration on ia11 (#1446)

### DIFF
--- a/src/Providers/SleepingOwlServiceProvider.php
+++ b/src/Providers/SleepingOwlServiceProvider.php
@@ -87,7 +87,9 @@ class SleepingOwlServiceProvider extends AdminSectionsServiceProvider
                 }
             );
 
-            $this->commands('command.sleepingowl.ide.generate');
+            if (class_exists('Barryvdh\LaravelIdeHelper\Console\GeneratorCommand')) {
+                $this->commands('command.sleepingowl.ide.generate');
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1446

## Problem

On a production install (`composer install --no-dev`) every artisan invocation — including `package:discover` on `post-autoload-dump`, so `composer install` itself — dies with:

```
Error: Class "Barryvdh\LaravelIdeHelper\Console\GeneratorCommand" not found
```

## Cause

`SleepingOwlServiceProvider::registerCommands()` adds `command.sleepingowl.ide.generate` to the console kernel unconditionally. Registering the command resolves the singleton, which instantiates `SleepingOwl\Admin\Console\Commands\GeneratorCommand`, whose parent class lives in `barryvdh/laravel-ide-helper` — a require-dev package that is absent on `--no-dev` installs. #1434 guarded the `IdeHelperServiceProvider` registration in the same method, but the command registration was left unguarded.

## Fix

Wrap the command registration in the same `class_exists()` guard:

```php
if (class_exists('Barryvdh\LaravelIdeHelper\Console\GeneratorCommand')) {
    $this->commands('command.sleepingowl.ide.generate');
}
```

The singleton binding stays as is — it is lazy and harmless; only adding the command to the kernel triggers the resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
